### PR TITLE
Make PrimaryUseCategoryCV nullable

### DIFF
--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/003/001. Core.PrimaryUseCategory.Nullable.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/003/001. Core.PrimaryUseCategory.Nullable.sql
@@ -1,0 +1,11 @@
+﻿ALTER TABLE [Core].AggregatedAmounts_fact
+ALTER COLUMN [PrimaryUseCategoryCV] NVARCHAR(100) NULL
+GO
+
+ALTER TABLE [Core].AllocationAmounts_fact
+ALTER COLUMN [PrimaryUseCategoryCV] NVARCHAR(100) NULL
+GO
+
+ALTER TABLE [Core].SiteVariableAmounts_fact
+ALTER COLUMN [PrimaryUseCategoryCV] NVARCHAR(100) NULL
+GO

--- a/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
+++ b/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
@@ -74,6 +74,7 @@
     <None Remove="Scripts\002\074 Core.LoadAggregatedAmounts Update.sql" />
     <None Remove="Scripts\002\075 Core.WaterAllocationBridgeIndexCreation.sql" />
     <None Remove="Scripts\003 Core.LoadAggregatedAmounts.sql" />
+    <None Remove="Scripts\003\001. Core.PrimaryUseCategory.Nullable.sql" />
     <None Remove="Scripts\004 Core.LoadMethods.sql" />
     <None Remove="Scripts\005 Core.LoadOrganization.sql" />
     <None Remove="Scripts\006 Core.LoadRegulatoryOverlays.sql" />
@@ -302,6 +303,7 @@
     <EmbeddedResource Include="Scripts\001\072 Input Tables Drop.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
+    <EmbeddedResource Include="Scripts\003\001. Core.PrimaryUseCategory.Nullable.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We need to allow Null for the PrimaryUseCategoryCV field. Most states input data has this field empty. So we can't enforce it.