### PR TITLE
Renamed foreign key columns of date_dim to include ID

### DIFF
--- a/source/WaDEApiFunctions/WaDEApiFunctions.csproj
+++ b/source/WaDEApiFunctions/WaDEApiFunctions.csproj
@@ -24,6 +24,9 @@
     <None Update="settings.nwilkinson.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="settings.zlannin.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="settings.znaminimianji.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AggregatedAmountsFact.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AggregatedAmountsFact.cs
@@ -19,7 +19,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public long MethodId { get; set; }
         public long? TimeframeStartId { get; set; }
         public long? TimeframeEndId { get; set; }
-        public long? DataPublicationDate { get; set; }
+        public long? DataPublicationDateID { get; set; }
         public string DataPublicationDoi { get; set; }
         public string ReportYearCv { get; set; }
         public double Amount { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AllocationAmountsFact.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AllocationAmountsFact.cs
@@ -19,15 +19,15 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public long DataPublicationDateId { get; set; }
         public string DataPublicationDoi { get; set; }
         public string AllocationNativeId { get; set; }
-        public long? AllocationApplicationDate { get; set; }
-        public long AllocationPriorityDate { get; set; }
-        public long? AllocationExpirationDate { get; set; }
+        public long? AllocationApplicationDateID { get; set; }
+        public long AllocationPriorityDateID { get; set; }
+        public long? AllocationExpirationDateID { get; set; }
         public string AllocationOwner { get; set; }
         public string AllocationBasisCv { get; set; }
         public string AllocationLegalStatusCv { get; set; }
         public string AllocationTypeCv { get; set; }
-        public long? AllocationTimeframeStart { get; set; }
-        public long? AllocationTimeframeEnd { get; set; }
+        public long? AllocationTimeframeStartID { get; set; }
+        public long? AllocationTimeframeEndID { get; set; }
         public double? AllocationCropDutyAmount { get; set; }
         public double? AllocationAmount { get; set; }
         public double? AllocationMaximum { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/SiteVariableAmountsFact.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/SiteVariableAmountsFact.cs
@@ -16,9 +16,9 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public long VariableSpecificId { get; set; }
         public long WaterSourceId { get; set; }
         public long MethodId { get; set; }
-        public long TimeframeStart { get; set; }
-        public long TimeframeEnd { get; set; }
-        public long DataPublicationDate { get; set; }
+        public long TimeframeStartID { get; set; }
+        public long TimeframeEndID { get; set; }
+        public long DataPublicationDateID { get; set; }
         public string DataPublicationDoi { get; set; }
         public string ReportYearCv { get; set; }
         public double Amount { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
@@ -158,7 +158,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
                 entity.Property(e => e.IrrigatedAcreage).HasColumnName("IrrigatedAcreage");
 
-                entity.Property(e => e.DataPublicationDate).HasColumnName("DataPublicationDate");
+                entity.Property(e => e.DataPublicationDateID).HasColumnName("DataPublicationDateID");
 
                 entity.Property(e => e.Amount).HasColumnName("Amount");
 
@@ -196,7 +196,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
                 entity.HasOne(d => d.DataPublicationDateNavigation)
                     .WithMany(p => p.AggregatedAmountsFactDataPublicationDateNavigation)
-                    .HasForeignKey(d => d.DataPublicationDate)
+                    .HasForeignKey(d => d.DataPublicationDateID)
                     .HasConstraintName("fk_AggregatedAmounts_Date_dim_end_pub");
 
                 entity.HasOne(d => d.Method)
@@ -334,9 +334,9 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                     .HasColumnName("SDWISIdentifierCV")
                     .HasMaxLength(100);
 
-                entity.Property(e => e.AllocationTimeframeEnd).HasMaxLength(5);
+                entity.Property(e => e.AllocationTimeframeEndID).HasMaxLength(5);
 
-                entity.Property(e => e.AllocationTimeframeStart).HasMaxLength(5);
+                entity.Property(e => e.AllocationTimeframeStartID).HasMaxLength(5);
 
                 entity.Property(e => e.AllocationTypeCv)
                     .HasColumnName("AllocationTypeCV")
@@ -345,17 +345,17 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                 entity.Property(e => e.DataPublicationDateId).HasColumnName("DataPublicationDateID");
 
                 //////////////////////////////////////////////////////////////////////////////
-                entity.Property(e => e.AllocationApplicationDate).HasColumnName("AllocationApplicationDate");
-                entity.Property(e => e.AllocationPriorityDate).HasColumnName("AllocationPriorityDate");
-                entity.Property(e => e.AllocationExpirationDate).HasColumnName("AllocationExpirationDate");
-                entity.Property(e => e.AllocationTimeframeStart).HasColumnName("AllocationTimeframeStart");
+                entity.Property(e => e.AllocationApplicationDateID).HasColumnName("AllocationApplicationDateID");
+                entity.Property(e => e.AllocationPriorityDateID).HasColumnName("AllocationPriorityDateID");
+                entity.Property(e => e.AllocationExpirationDateID).HasColumnName("AllocationExpirationDateID");
+                entity.Property(e => e.AllocationTimeframeStartID).HasColumnName("AllocationTimeframeStartID");
                 entity.Property(e => e.AllocationCropDutyAmount).HasColumnName("AllocationCropDutyAmount");
                 entity.Property(e => e.AllocationAmount).HasColumnName("AllocationAmount");
                 entity.Property(e => e.AllocationMaximum).HasColumnName("AllocationMaximum");
                 entity.Property(e => e.PopulationServed).HasColumnName("PopulationServed");
                 entity.Property(e => e.IrrigatedAcreage).HasColumnName("IrrigatedAcreage");
                 entity.Property(e => e.AllocationCommunityWaterSupplySystem).HasColumnName("AllocationCommunityWaterSupplySystem");
-                entity.Property(e => e.AllocationTimeframeEnd).HasColumnName("AllocationTimeframeEnd");
+                entity.Property(e => e.AllocationTimeframeEndID).HasColumnName("AllocationTimeframeEndID");
                 entity.Property(e => e.AllocationChangeApplicationIndicator).HasColumnName("AllocationChangeApplicationIndicator");
                 entity.Property(e => e.AllocationOwner)
                     .HasColumnName("AllocationOwner")
@@ -405,7 +405,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
                 entity.HasOne(d => d.AllocationApplicationDateNavigation)
                     .WithMany(p => p.AllocationAmountsFactAllocationApplicationDateNavigation)
-                    .HasForeignKey(d => d.AllocationApplicationDate)
+                    .HasForeignKey(d => d.AllocationApplicationDateID)
                     .HasConstraintName("fk_AllocationAmounts_fact_Date_dim_appl");
 
                 entity.HasOne(d => d.AllocationBasisCvNavigation)
@@ -415,7 +415,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
                 entity.HasOne(d => d.AllocationExpirationDateNavigation)
                     .WithMany(p => p.AllocationAmountsFactAllocationExpirationDateNavigation)
-                    .HasForeignKey(d => d.AllocationExpirationDate)
+                    .HasForeignKey(d => d.AllocationExpirationDateID)
                     .HasConstraintName("fk_AllocationAmounts_fact_Date_dim_expir");
 
                 entity.HasOne(d => d.AllocationLegalStatusCvNavigation)
@@ -425,7 +425,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
                 entity.HasOne(d => d.AllocationPriorityDateNavigation)
                     .WithMany(p => p.AllocationAmountsFactAllocationPriorityDateNavigation)
-                    .HasForeignKey(d => d.AllocationPriorityDate)
+                    .HasForeignKey(d => d.AllocationPriorityDateID)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("fk_AllocationAmounts_fact_Date_dim_priority");
 
@@ -433,12 +433,12 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                 // 
                 entity.HasOne(d => d.AllocationTimeFrameStartNavigation)
                     .WithMany(p => p.AllocationAmountsFactTimeframeStart)
-                    .HasForeignKey(d => d.AllocationTimeframeStart)
+                    .HasForeignKey(d => d.AllocationTimeframeStartID)
                     .HasConstraintName("FK_AllocationTimeFrameStart_Date_dim");
 
                 entity.HasOne(d => d.AllocationTimeFrameEndNavigation)
                     .WithMany(p => p.AllocationAmountsFactTimeframeEnd)
-                    .HasForeignKey(d => d.AllocationTimeframeEnd)
+                    .HasForeignKey(d => d.AllocationTimeframeEndID)
                     .HasConstraintName("FK_AllocationTimeFrameEnd_Date_dim");
 
                 //////////////////////////////////
@@ -1351,9 +1351,9 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                 entity.Property(e => e.MethodId).HasColumnName("MethodID");
 
                 ///////////////////////////////////////////////////////////////
-                entity.Property(e => e.TimeframeEnd).HasColumnName("TimeFrameEnd");
-                entity.Property(e => e.TimeframeStart).HasColumnName("TimeFrameStart");
-                entity.Property(e => e.DataPublicationDate).HasColumnName("DataPublicationDate");
+                entity.Property(e => e.TimeframeEndID).HasColumnName("TimeFrameEndID");
+                entity.Property(e => e.TimeframeStartID).HasColumnName("TimeFrameStartID");
+                entity.Property(e => e.DataPublicationDateID).HasColumnName("DataPublicationDateID");
                 entity.Property(e => e.Amount).HasColumnName("Amount");
                 entity.Property(e => e.PopulationServed).HasColumnName("PopulationServed");
                 entity.Property(e => e.IrrigatedAcreage).HasColumnName("IrrigatedAcreage");
@@ -1392,7 +1392,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
                 entity.HasOne(d => d.DataPublicationDateNavigation)
                     .WithMany(p => p.SiteVariableAmountsFactDataPublicationDateNavigation)
-                    .HasForeignKey(d => d.DataPublicationDate)
+                    .HasForeignKey(d => d.DataPublicationDateID)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("fk_SiteVariableAmounts_Date_dim_pub");
 
@@ -1426,13 +1426,13 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
                 entity.HasOne(d => d.TimeframeEndNavigation)
                     .WithMany(p => p.SiteVariableAmountsFactTimeframeEndNavigation)
-                    .HasForeignKey(d => d.TimeframeEnd)
+                    .HasForeignKey(d => d.TimeframeEndID)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("fk_SiteVariableAmounts_Date_dim_end");
 
                 entity.HasOne(d => d.TimeframeStartNavigation)
                     .WithMany(p => p.SiteVariableAmountsFactTimeframeStartNavigation)
-                    .HasForeignKey(d => d.TimeframeStart)
+                    .HasForeignKey(d => d.TimeframeStartID)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("fk_SiteVariableAmounts_Date_dim_start");
 

--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/003/002 Core.RenameDateForeignKeyColumns.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/003/002 Core.RenameDateForeignKeyColumns.sql
@@ -1,0 +1,14 @@
+﻿-- ALLOCATION AMOUNTS TABLE
+EXEC sp_rename 'Core.AllocationAmounts_fact.AllocationApplicationDate', 'AllocationApplicationDateID', 'COLUMN'
+EXEC sp_rename 'Core.AllocationAmounts_fact.AllocationExpirationDate', 'AllocationExpirationDateID', 'COLUMN'
+EXEC sp_rename 'Core.AllocationAmounts_fact.AllocationPriorityDate', 'AllocationPriorityDateID', 'COLUMN'
+EXEC sp_rename 'Core.AllocationAmounts_fact.AllocationTimeframeEnd', 'AllocationTimeframeEndID', 'COLUMN'
+EXEC sp_rename 'Core.AllocationAmounts_fact.AllocationTimeframeStart', 'AllocationTimeframeStartID', 'COLUMN'
+
+-- AGGREGATED AMOUNTS TABLE
+EXEC sp_rename 'Core.AggregatedAmounts_fact.DataPublicationDate', 'DataPublicationDateID', 'COLUMN'
+
+-- SITE VARIABLE AMOUNTS
+EXEC sp_rename 'Core.SiteVariableAmounts_fact.DataPublicationDate', 'DataPublicationDateID', 'COLUMN'
+EXEC sp_rename 'Core.SiteVariableAmounts_fact.TimeframeEnd', 'TimeframeEndID', 'COLUMN'
+EXEC sp_rename 'Core.SiteVariableAmounts_fact.TimeframeStart', 'TimeframeStartID', 'COLUMN'

--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/003/002 Core.RenameDateForeignKeyColumns.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/003/002 Core.RenameDateForeignKeyColumns.sql
@@ -12,3 +12,354 @@ EXEC sp_rename 'Core.AggregatedAmounts_fact.DataPublicationDate', 'DataPublicati
 EXEC sp_rename 'Core.SiteVariableAmounts_fact.DataPublicationDate', 'DataPublicationDateID', 'COLUMN'
 EXEC sp_rename 'Core.SiteVariableAmounts_fact.TimeframeEnd', 'TimeframeEndID', 'COLUMN'
 EXEC sp_rename 'Core.SiteVariableAmounts_fact.TimeframeStart', 'TimeframeStartID', 'COLUMN'
+GO
+
+ALTER PROCEDURE [Core].[LoadWaterAllocation]
+(
+	@RunId nvarchar(250),
+	@WaterAllocationTable Core.WaterAllocationTableType READONLY
+)
+AS
+BEGIN
+	SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) RowNumber, *
+	INTO #TempWaterAllocationData
+	FROM @WaterAllocationTable;
+
+	--wire up the foreign keys
+	SELECT
+		wad.*
+		,o.OrganizationID
+		,v.VariableSpecificID
+		,ws.WaterSourceID
+		,m.MethodID
+		,bs.Name PrimaryUseCategoryCV
+		,CASE WHEN PopulationServed IS NULL OR CommunityWaterSupplySystem IS NULL 
+						OR CustomerType IS NULL OR AllocationSDWISIdentifier IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN IrrigatedAcreage IS NULL OR CropTypeCV IS NULL 
+						OR IrrigationMethodCV IS NULL OR AllocationCropDutyAmount IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN PowerGeneratedGWh IS NULL THEN 0 ELSE 1 END CategoryCount
+	INTO
+		#TempJoinedWaterAllocationData
+	FROM
+		#TempWaterAllocationData wad
+		LEFT OUTER JOIN Core.Organizations_dim o ON o.OrganizationUUID = wad.OrganizationUUID
+		LEFT OUTER JOIN Core.Variables_dim v ON v.VariableSpecificUUID = wad.VariableSpecificUUID
+		LEFT OUTER JOIN Core.WaterSources_dim ws ON ws.WaterSourceUUID = wad.WaterSourceUUID
+		LEFT OUTER JOIN CVs.BeneficialUses bs ON bs.Name=wad.PrimaryUseCategory
+		LEFT OUTER JOIN Core.Methods_dim m ON m.MethodUUID = wad.MethodUUID;
+		
+	--data validation
+	WITH q1 AS
+	(
+		SELECT 'OrganizationID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE OrganizationID IS NULL
+		UNION ALL
+		SELECT 'VariableSpecificID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE VariableSpecificID IS NULL
+		UNION ALL
+		SELECT 'WaterSourceID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE WaterSourceID IS NULL
+		UNION ALL
+		SELECT 'PrimaryUseCategoryCV Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE PrimaryUseCategoryCV IS NULL
+		UNION ALL
+		SELECT 'MethodID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE MethodID IS NULL
+		UNION ALL
+		SELECT 'DataPublicationDateID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE DataPublicationDate IS NULL
+		UNION ALL
+		SELECT 'AllocationPriorityDateID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE AllocationPriorityDate IS NULL
+		--//////////////////////////////s
+		UNION ALL
+		SELECT 'Cross Group Not Valid' Reason, *
+        FROM #TempJoinedWaterAllocationData
+        WHERE CategoryCount >1
+		--//////////////////////////////////e
+	)
+	SELECT * INTO #TempErrorWaterAllocationRecords FROM q1;
+
+	--if we have errors, insert them and bail out
+	IF EXISTS(SELECT 1 FROM #TempErrorWaterAllocationRecords) 
+	BEGIN
+		INSERT INTO Core.ImportErrors ([Type], [RunId], [Data])
+		VALUES ('WaterAllocations', @RunId, (SELECT * FROM #TempErrorWaterAllocationRecords FOR JSON PATH));
+		RETURN 1;
+	END
+
+	--set up missing Core.BeneficialUses_dim entries
+	SELECT
+		wad.RowNumber
+		,BeneficialUse = TRIM(bu.[Value]) 
+	INTO
+		#TempBeneficialUsesData
+	FROM
+		#TempWaterAllocationData wad
+		CROSS APPLY STRING_SPLIT(wad.BeneficialUseCategory, ',') bu
+	WHERE
+		wad.PrimaryUseCategory IS NOT NULL
+		AND bu.[Value] IS NOT NULL
+		AND LEN(TRIM(bu.[Value])) > 0;
+
+	--INSERT INTO
+	--	CVs.BeneficialUses(Name)
+ --   SELECT DISTINCT
+	--	bud.BeneficialUse
+ --   FROM
+	--	#TempBeneficialUsesData bud
+	--	LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = bud.BeneficialUse
+ --     WHERE
+	--	bu.Name IS NULL;
+
+	--INSERT INTO
+	--	CVs.BeneficialUses(Name)
+	--SELECT DISTINCT
+	--	wad.PrimaryUseCategory
+	--FROM
+	--	#TempWaterAllocationData wad
+	--	LEFT OUTER JOIN CVs.BeneficialUses bu on bu.Name = wad.PrimaryUseCategory
+	--WHERE
+	--	bu.Name IS NULL
+	--	AND wad.PrimaryUseCategory IS NOT NULL
+	--	AND LEN(TRIM(wad.PrimaryUseCategory)) > 0;
+
+	--set up missing Core.Sites_dim entries
+	SELECT
+		wad.RowNumber
+		,SiteUUID = TRIM(s.[Value]) 
+	INTO
+		#TempSitesData
+	FROM
+		#TempWaterAllocationData wad
+		CROSS APPLY STRING_SPLIT(wad.SiteUUID, ',') s
+	WHERE
+		s.[Value] IS NOT NULL
+		AND LEN(TRIM(s.[Value])) > 0;
+
+	--set up missing Core.Date_dim entries
+	WITH q1 AS
+	(
+		SELECT [Date]
+		FROM #TempWaterAllocationData wad
+		UNPIVOT ([Date] FOR Dates IN (wad.DataPublicationDATE, wad.AllocationApplicationDate, wad.AllocationPriorityDate, wad.AllocationExpirationDate, wad.AllocationTimeframeStart, wad.AllocationTimeframeEnd)) AS up
+	)
+	INSERT INTO Core.Date_dim (Date, Year)
+	SELECT
+		q1.[Date]
+		,YEAR(q1.[Date])
+	FROM
+		q1
+		LEFT OUTER JOIN Core.Date_dim d ON q1.[Date] = d.[Date]
+	WHERE
+        d.DateID IS NULL AND q1.[Date] IS NOT NULL
+    GROUP BY
+        q1.[Date];
+ 
+	--merge into Core.AllocationAmounts_fact
+	CREATE TABLE #AllocationAmountRecords(AllocationAmountID BIGINT, RowNumber BIGINT);
+
+	WITH q1 AS
+	(
+		SELECT
+			wad.OrganizationID
+			,wad.VariableSpecificID
+			,wad.WaterSourceID
+			,wad.MethodID
+			,wad.PrimaryUseCategory
+			,DataPublicationDateID = dpub.DateID
+			,wad.DataPublicationDOI
+			,wad.AllocationNativeID
+			,AllocationApplicationDateID = dApp.DateID
+			,AllocationPriorityDateID = dPri.DateID
+			,AllocationExpirationDateID = dExp.DateID
+			,wad.AllocationOwner
+			,wad.AllocationBasisCV
+			,wad.AllocationLegalStatusCV
+			,wad.AllocationTypeCV
+			,AllocationTimeframeStartID = dStart.DateID
+			,AllocationTimeframeEndID = dEnd.DateID
+			,wad.AllocationCropDutyAmount
+			,wad.AllocationAmount
+			,wad.AllocationMaximum
+			,wad.PopulationServed
+			,wad.PowerGeneratedGWh
+			,wad.IrrigatedAcreage
+			,wad.AllocationCommunityWaterSupplySystem
+			,wad.AllocationSDWISIdentifier
+			,wad.AllocationAssociatedWithdrawalSiteIDs
+			,wad.AllocationAssociatedConsumptiveUseSiteIDs
+			,wad.AllocationChangeApplicationIndicator
+			,wad.LegacyAllocationIDs
+			,wad.RowNumber
+			,wad.CropTypeCV
+			,wad.CustomerType
+			
+			,wad.IrrigationMethodCV
+			,wad.CommunityWaterSupplySystem
+		FROM
+			#TempJoinedWaterAllocationData wad
+			--LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = wad.PrimaryUseCategory
+			LEFT OUTER JOIN Core.Date_dim dPub ON dPub.[Date] = wad.DataPublicationDate
+			LEFT OUTER JOIN Core.Date_dim dApp ON dApp.[Date] = wad.AllocationApplicationDate
+			LEFT OUTER JOIN Core.Date_dim dPri ON dPri.[Date] = wad.AllocationPriorityDate
+			LEFT OUTER JOIN Core.Date_dim dExp ON dExp.[Date] = wad.AllocationExpirationDate
+			LEFT OUTER JOIN Core.Date_dim dStart ON dStart.[Date] = wad.AllocationTimeframeStart
+			LEFT OUTER JOIN Core.Date_dim dEnd ON dEnd.[Date] = wad.AllocationTimeframeEnd
+	)
+	MERGE INTO Core.AllocationAmounts_fact AS Target
+	USING q1 AS Source ON
+		ISNULL(Target.OrganizationID, '') = ISNULL(Source.OrganizationID, '')
+		AND ISNULL(Target.AllocationNativeID, '') = ISNULL(Source.AllocationNativeID, '')
+		AND ISNULL(Target.VariableSpecificID, '') = ISNULL(Source.VariableSpecificID, '')
+		AND ISNULL(Target.PrimaryUseCategoryCV, '') = ISNULL(Source.PrimaryUseCategory, '')
+	WHEN NOT MATCHED THEN
+	INSERT
+		(OrganizationID
+		,VariableSpecificID
+		,WaterSourceID
+		,MethodID
+		,PrimaryUseCategoryCV
+		,DataPublicationDateID
+		,DataPublicationDOI
+		,AllocationNativeID
+		,AllocationApplicationDateID
+		,AllocationPriorityDateID
+		,AllocationExpirationDateID
+		,AllocationOwner
+		,AllocationBasisCV
+		,AllocationLegalStatusCV
+		,AllocationTypeCV
+		,AllocationTimeframeStartID
+		,AllocationTimeframeEndID
+		,AllocationCropDutyAmount
+		,AllocationAmount
+		,AllocationMaximum
+		,PopulationServed
+		,PowerGeneratedGWh
+		,IrrigatedAcreage
+		,AllocationCommunityWaterSupplySystem
+		,SDWISIdentifierCV
+		,AllocationAssociatedWithdrawalSiteIDs
+		,AllocationAssociatedConsumptiveUseSiteIDs
+		,AllocationChangeApplicationIndicator
+		,LegacyAllocationIDs
+		,CropTypeCV
+		,CustomerTypeCV
+		
+		,IrrigationMethodCV
+		,CommunityWaterSupplySystem)
+	VALUES
+		(Source.OrganizationID
+		,Source.VariableSpecificID
+		,Source.WaterSourceID
+		,Source.MethodID
+		,Source.PrimaryUseCategory
+		,Source.DataPublicationDateID
+		,Source.DataPublicationDOI
+		,Source.AllocationNativeID
+		,Source.AllocationApplicationDateID
+		,Source.AllocationPriorityDateID
+		,Source.AllocationExpirationDateID
+		,Source.AllocationOwner
+		,Source.AllocationBasisCV
+		,Source.AllocationLegalStatusCV
+		,Source.AllocationTypeCV
+		,Source.AllocationTimeframeStartID
+		,Source.AllocationTimeframeEndID
+		,Source.AllocationCropDutyAmount
+		,Source.AllocationAmount
+		,Source.AllocationMaximum
+		,Source.PopulationServed
+		,Source.PowerGeneratedGWh
+		,Source.IrrigatedAcreage
+		,Source.AllocationCommunityWaterSupplySystem
+		,Source.AllocationSDWISIdentifier
+		,Source.AllocationAssociatedWithdrawalSiteIDs
+		,Source.AllocationAssociatedConsumptiveUseSiteIDs
+		,Source.AllocationChangeApplicationIndicator
+		,Source.LegacyAllocationIDs
+		,Source.CropTypeCV
+		,Source.CustomerType
+		,Source.IrrigationMethodCV
+		,Source.CommunityWaterSupplySystem)
+	WHEN MATCHED THEN
+	  UPDATE SET
+		OrganizationID = Source.OrganizationID,
+		VariableSpecificID = Source.VariableSpecificID,
+		WaterSourceID = Source.WaterSourceID,
+		MethodID = Source.MethodID,
+		PrimaryUseCategoryCV = Source.PrimaryUseCategory,
+		DataPublicationDateID = Source.DataPublicationDateID,
+		DataPublicationDOI = Source.DataPublicationDOI,
+		AllocationNativeID = Source.AllocationNativeID,
+		AllocationApplicationDateID = Source.AllocationApplicationDateID,
+		AllocationPriorityDateID = Source.AllocationPriorityDateID,
+		AllocationExpirationDateID = Source.AllocationExpirationDateID,
+		AllocationOwner = Source.AllocationOwner,
+		AllocationBasisCV = Source.AllocationBasisCV,
+		AllocationLegalStatusCV = Source.AllocationLegalStatusCV,
+		AllocationTypeCV = Source.AllocationTypeCV,
+		AllocationTimeframeStartID = Source.AllocationTimeframeStartID,
+		AllocationTimeframeEndID = Source.AllocationTimeframeEndID,
+		AllocationCropDutyAmount = Source.AllocationCropDutyAmount,
+		AllocationAmount = Source.AllocationAmount,
+		AllocationMaximum = Source.AllocationMaximum,
+		PopulationServed = Source.PopulationServed,
+		PowerGeneratedGWh = Source.PowerGeneratedGWh,
+		IrrigatedAcreage = Source.IrrigatedAcreage,
+		AllocationCommunityWaterSupplySystem = Source.AllocationCommunityWaterSupplySystem,
+		SDWISIdentifierCV = Source.AllocationSDWISIdentifier,
+		AllocationAssociatedWithdrawalSiteIDs = Source.AllocationAssociatedWithdrawalSiteIDs,
+		AllocationAssociatedConsumptiveUseSiteIDs = Source.AllocationAssociatedConsumptiveUseSiteIDs,
+		AllocationChangeApplicationIndicator = Source.AllocationChangeApplicationIndicator,
+		LegacyAllocationIDs = Source.LegacyAllocationIDs,
+		CropTypeCV = Source.CropTypeCV,
+		CustomerTypeCV = Source.CustomerType,
+		IrrigationMethodCV = Source.IrrigationMethodCV,
+		CommunityWaterSupplySystem = Source.CommunityWaterSupplySystem
+		
+	OUTPUT
+		inserted.AllocationAmountID
+		,Source.RowNumber
+	INTO
+		#AllocationAmountRecords;
+
+	
+	--insert into Core.AllocationBridge_BeneficialUses_fact
+	INSERT INTO Core.AllocationBridge_BeneficialUses_fact (BeneficialUseCV, AllocationAmountID)
+	SELECT DISTINCT
+		bu.Name
+		,aar.AllocationAmountID
+	FROM
+		#AllocationAmountRecords aar
+		LEFT OUTER JOIN #TempBeneficialUsesData bud ON bud.RowNumber = aar.RowNumber
+		LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = bud.BeneficialUse
+	WHERE
+		bu.Name IS NOT NULL AND
+		NOT EXISTS(SELECT 1 from Core.AllocationBridge_BeneficialUses_fact innerAB where innerAB.AllocationAmountID = aar.AllocationAmountID and innerAB.BeneficialUseCV = bu.Name);
+
+	--insert into Core.AllocationBridge_Sites_fact
+	INSERT INTO Core.AllocationBridge_Sites_fact (SiteID, AllocationAmountID)
+	SELECT DISTINCT
+		s.SiteID
+		,aar.AllocationAmountID
+	FROM
+		#AllocationAmountRecords aar
+		LEFT OUTER JOIN #TempSitesData siteData ON siteData.RowNumber = aar.RowNumber
+		LEFT OUTER JOIN Sites_dim s ON s.WaDESiteUUID = siteData.SiteUUID
+	WHERE
+		s.SiteID IS NOT NULL AND
+		NOT EXISTS(SELECT 1 from Core.AllocationBridge_Sites_fact innerAB where innerAB.AllocationAmountID = aar.AllocationAmountID and innerAB.SiteID = s.SiteID);
+	RETURN 0;
+
+END

--- a/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
+++ b/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
@@ -74,6 +74,7 @@
     <None Remove="Scripts\002\074 Core.LoadAggregatedAmounts Update.sql" />
     <None Remove="Scripts\002\075 Core.WaterAllocationBridgeIndexCreation.sql" />
     <None Remove="Scripts\003 Core.LoadAggregatedAmounts.sql" />
+    <None Remove="Scripts\003\002 Core.RenameDateForeignKeyColumns.sql" />
     <None Remove="Scripts\004 Core.LoadMethods.sql" />
     <None Remove="Scripts\005 Core.LoadOrganization.sql" />
     <None Remove="Scripts\006 Core.LoadRegulatoryOverlays.sql" />
@@ -302,6 +303,7 @@
     <EmbeddedResource Include="Scripts\001\072 Input Tables Drop.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
+    <EmbeddedResource Include="Scripts\003\002 Core.RenameDateForeignKeyColumns.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
All "date" fields that are foreign keys to the Date table in those fact tables need to include "ID" at the end of them.

Found all the columns by running the SP `EXEC sp_fkeys @pktable_name = 'Date_dim', @pktable_owner = 'Core'`.