### PR TITLE
Fix: Empty PrimaryUseCategory Not Populating Bridge Tables

### DIFF
--- a/source/WesternStatesWater.WaDE.Accessors.Tests/ImportWaterAllocationAccessorTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/ImportWaterAllocationAccessorTests.cs
@@ -44,7 +44,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 dataPublicationDate = await DateDimBuilder.Load(db);
                 allocationPriorityDate = await DateDimBuilder.Load(db);
 
-                waterAllocation = WaterAllocationBuilder.Create(new WaterAllocationBuilderOptions{RecordType = WaterAllocationRecordType.None});
+                waterAllocation = WaterAllocationBuilder.Create(new WaterAllocationBuilderOptions { RecordType = WaterAllocationRecordType.None });
 
                 waterAllocation.OrganizationUUID = organization.OrganizationUuid;
                 waterAllocation.VariableSpecificUUID = variable.VariableSpecificUuid;
@@ -57,7 +57,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             }
 
             var sut = CreateWaterAllocationAccessor();
-            var result = await sut.LoadWaterAllocation((new Faker()).Random.AlphaNumeric(10), new[] {waterAllocation});
+            var result = await sut.LoadWaterAllocation((new Faker()).Random.AlphaNumeric(10), new[] { waterAllocation });
 
             result.Should().BeTrue();
 
@@ -97,7 +97,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 dataPublicationDate = await DateDimBuilder.Load(db);
                 allocationPriorityDate = await DateDimBuilder.Load(db);
 
-                waterAllocation = WaterAllocationBuilder.Create(new WaterAllocationBuilderOptions{RecordType = WaterAllocationRecordType.Civilian});
+                waterAllocation = WaterAllocationBuilder.Create(new WaterAllocationBuilderOptions { RecordType = WaterAllocationRecordType.Civilian });
 
                 waterAllocation.OrganizationUUID = organization.OrganizationUuid;
                 waterAllocation.VariableSpecificUUID = variable.VariableSpecificUuid;
@@ -122,6 +122,119 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 var importError = db.ImportErrors.Single();
                 importError.RunId.Should().Be(runId);
                 importError.Data.Should().Contain("Cross Group Not Valid");
+            }
+        }
+
+        [TestMethod]
+        public async Task LoadWaterAllocation_LoadAllocationBridge_PrimaryUseCategoryCV_Null()
+        {
+            OrganizationsDim organization;
+            VariablesDim variable;
+            WaterSourcesDim waterSource;
+            MethodsDim method;
+            DateDim dataPublicationDate;
+            DateDim allocationPriorityDate;
+            WaterAllocation waterAllocation;
+            BeneficialUsesCV beneficialUsesCV;
+            string startTestString = "01/01";
+            string endTestString = "12/01";
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                organization = await OrganizationsDimBuilder.Load(db);
+                variable = await VariablesDimBuilder.Load(db);
+                waterSource = await WaterSourcesDimBuilder.Load(db);
+                method = await MethodsDimBuilder.Load(db);
+                dataPublicationDate = await DateDimBuilder.Load(db);
+                allocationPriorityDate = await DateDimBuilder.Load(db);
+                beneficialUsesCV = await BeneficalUsesBuilder.Load(db);
+
+                waterAllocation = WaterAllocationBuilder.Create(new WaterAllocationBuilderOptions { RecordType = WaterAllocationRecordType.None });
+
+                waterAllocation.PrimaryUseCategory = null;
+
+                waterAllocation.BeneficialUseCategory = beneficialUsesCV.Name;
+                waterAllocation.OrganizationUUID = organization.OrganizationUuid;
+                waterAllocation.VariableSpecificUUID = variable.VariableSpecificUuid;
+                waterAllocation.WaterSourceUUID = waterSource.WaterSourceUuid;
+                waterAllocation.MethodUUID = method.MethodUuid;
+                waterAllocation.DataPublicationDate = dataPublicationDate.Date;
+                waterAllocation.AllocationPriorityDate = allocationPriorityDate.Date;
+                waterAllocation.AllocationTimeframeStart = startTestString;
+                waterAllocation.AllocationTimeframeEnd = endTestString;
+            }
+
+            var sut = CreateWaterAllocationAccessor();
+            var result = await sut.LoadWaterAllocation((new Faker()).Random.AlphaNumeric(10), new[] { waterAllocation });
+
+            result.Should().BeTrue();
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                var dbAllocationAmount = await db.AllocationAmountsFact.SingleAsync();
+                dbAllocationAmount.Should().NotBeNull();
+                dbAllocationAmount.PrimaryUseCategoryCV.Should().BeNull();
+
+                var dbAllocationBridge = await db.AllocationBridgeBeneficialUsesFact.SingleAsync();
+                dbAllocationBridge.Should().NotBeNull();
+
+                db.ImportErrors.Should().HaveCount(0);
+            }
+        }
+
+        [TestMethod]
+        public async Task LoadWaterAllocation_LoadAggBridge_PrimaryUseCategoryCV_Null()
+        {
+            OrganizationsDim organization;
+            ReportingUnitsDim reportingUnit;
+            VariablesDim variable;
+            WaterSourcesDim waterSource;
+            MethodsDim method;
+            DateDim dataPublicationDate;
+            DateDim allocationPriorityDate;
+            AggregatedAmount aggregateAmount;
+            BeneficialUsesCV beneficialUsesCV;
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                organization = await OrganizationsDimBuilder.Load(db);
+                reportingUnit = await ReportingUnitsDimBuilder.Load(db);
+                variable = await VariablesDimBuilder.Load(db);
+                waterSource = await WaterSourcesDimBuilder.Load(db);
+                method = await MethodsDimBuilder.Load(db);
+                dataPublicationDate = await DateDimBuilder.Load(db);
+                allocationPriorityDate = await DateDimBuilder.Load(db);
+                beneficialUsesCV = await BeneficalUsesBuilder.Load(db);
+
+                aggregateAmount = AggregatedAmountBuilder.Create();
+
+                aggregateAmount.PrimaryUseCategory = null;
+                
+                aggregateAmount.ReportingUnitUUID = reportingUnit.ReportingUnitUuid;
+                aggregateAmount.BeneficialUseCategory = beneficialUsesCV.Name;
+                aggregateAmount.OrganizationUUID = organization.OrganizationUuid;
+                aggregateAmount.VariableSpecificUUID = variable.VariableSpecificUuid;
+                aggregateAmount.WaterSourceUUID = waterSource.WaterSourceUuid;
+                aggregateAmount.MethodUUID = method.MethodUuid;
+                aggregateAmount.DataPublicationDate = dataPublicationDate.Date;
+            }
+
+            var sut = CreateWaterAllocationAccessor();
+            
+            var result = await sut.LoadAggregatedAmounts((new Faker()).Random.AlphaNumeric(10), new[] { aggregateAmount });
+
+            result.Should().BeTrue();
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                var dbAggregateAmount = await db.AggregatedAmountsFact.SingleAsync();
+                dbAggregateAmount.Should().NotBeNull();
+                dbAggregateAmount.PrimaryUseCategoryCV.Should().BeNull();
+
+                var dbAllocationBridge = await db.AggBridgeBeneficialUsesFact.SingleAsync();
+                dbAllocationBridge.Should().NotBeNull();
+                
+                db.ImportErrors.Should().HaveCount(0);
             }
         }
 

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/ImportWaterAllocationAccessorTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/ImportWaterAllocationAccessorTests.cs
@@ -244,7 +244,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 db.ImportErrors.Should().HaveCount(errorCount + 1);
                 var error = await db.ImportErrors.LastAsync();
                 error.Data.Should().Contain("Allocation Not Exempt of Volume Flow Priority");
-                
+
             }
         }
 
@@ -300,6 +300,67 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
         }
 
         [TestMethod]
+        public async Task LoadWaterAllocation_LoadAllocationBridge_PrimaryUseCategoryCV_Populated()
+        {
+            OrganizationsDim organization;
+            VariablesDim variable;
+            WaterSourcesDim waterSource;
+            MethodsDim method;
+            DateDim dataPublicationDate;
+            DateDim allocationPriorityDate;
+            WaterAllocation waterAllocation;
+            BeneficialUsesCV beneficialUsesCV;
+            BeneficialUsesCV primaryUseCategoryCV;
+            string startTestString = "01/01";
+            string endTestString = "12/01";
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                organization = await OrganizationsDimBuilder.Load(db);
+                variable = await VariablesDimBuilder.Load(db);
+                waterSource = await WaterSourcesDimBuilder.Load(db);
+                method = await MethodsDimBuilder.Load(db);
+                dataPublicationDate = await DateDimBuilder.Load(db);
+                allocationPriorityDate = await DateDimBuilder.Load(db);
+                beneficialUsesCV = await BeneficalUsesBuilder.Load(db);
+                primaryUseCategoryCV = await BeneficalUsesBuilder.Load(db);
+
+                waterAllocation = WaterAllocationBuilder.Create(new WaterAllocationBuilderOptions { RecordType = WaterAllocationRecordType.None });
+
+                waterAllocation.PrimaryUseCategory = primaryUseCategoryCV.Name;
+
+                waterAllocation.BeneficialUseCategory = beneficialUsesCV.Name;
+                waterAllocation.OrganizationUUID = organization.OrganizationUuid;
+                waterAllocation.VariableSpecificUUID = variable.VariableSpecificUuid;
+                waterAllocation.WaterSourceUUID = waterSource.WaterSourceUuid;
+                waterAllocation.MethodUUID = method.MethodUuid;
+                waterAllocation.DataPublicationDate = dataPublicationDate.Date;
+                waterAllocation.AllocationPriorityDate = allocationPriorityDate.Date;
+                waterAllocation.AllocationTimeframeStart = startTestString;
+                waterAllocation.AllocationTimeframeEnd = endTestString;
+            }
+
+            var sut = CreateWaterAllocationAccessor();
+            var result = await sut.LoadWaterAllocation((new Faker()).Random.AlphaNumeric(10), new[] { waterAllocation });
+
+            result.Should().BeTrue();
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                var dbAllocationAmount = await db.AllocationAmountsFact.SingleAsync();
+                dbAllocationAmount.Should().NotBeNull();
+                dbAllocationAmount.PrimaryUseCategoryCV.Should().Be(primaryUseCategoryCV.Name);
+
+                var dbAllocationBridge = await db.AllocationBridgeBeneficialUsesFact.SingleAsync();
+                dbAllocationBridge.Should().NotBeNull();
+                dbAllocationBridge.AllocationAmountId.Should().BeGreaterThan(0);
+                dbAllocationBridge.BeneficialUseCV.Should().Be(beneficialUsesCV.Name);
+
+                db.ImportErrors.Should().HaveCount(0);
+            }
+        }
+
+        [TestMethod]
         public async Task LoadWaterAllocation_LoadAllocationBridge_PrimaryUseCategoryCV_Null()
         {
             OrganizationsDim organization;
@@ -351,6 +412,71 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
 
                 var dbAllocationBridge = await db.AllocationBridgeBeneficialUsesFact.SingleAsync();
                 dbAllocationBridge.Should().NotBeNull();
+                dbAllocationBridge.AllocationBridgeId.Should().BeGreaterThan(0);
+                dbAllocationBridge.AllocationAmountId.Should().Be(dbAllocationBridge.AllocationAmountId);
+                dbAllocationBridge.BeneficialUseCV.Should().Be(beneficialUsesCV.Name);
+
+                db.ImportErrors.Should().HaveCount(0);
+            }
+        }
+
+        [TestMethod]
+        public async Task LoadWaterAllocation_LoadAggBridge_PrimaryUseCategoryCV_Populated()
+        {
+            OrganizationsDim organization;
+            ReportingUnitsDim reportingUnit;
+            VariablesDim variable;
+            WaterSourcesDim waterSource;
+            MethodsDim method;
+            DateDim dataPublicationDate;
+            DateDim allocationPriorityDate;
+            AggregatedAmount aggregateAmount;
+            BeneficialUsesCV beneficialUsesCV;
+            BeneficialUsesCV primaryUseCategoryCV;
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                organization = await OrganizationsDimBuilder.Load(db);
+                reportingUnit = await ReportingUnitsDimBuilder.Load(db);
+                variable = await VariablesDimBuilder.Load(db);
+                waterSource = await WaterSourcesDimBuilder.Load(db);
+                method = await MethodsDimBuilder.Load(db);
+                dataPublicationDate = await DateDimBuilder.Load(db);
+                allocationPriorityDate = await DateDimBuilder.Load(db);
+                beneficialUsesCV = await BeneficalUsesBuilder.Load(db);
+                primaryUseCategoryCV = await BeneficalUsesBuilder.Load(db);
+
+                aggregateAmount = AggregatedAmountBuilder.Create();
+
+                aggregateAmount.PrimaryUseCategory = primaryUseCategoryCV.Name;
+
+                aggregateAmount.ReportingUnitUUID = reportingUnit.ReportingUnitUuid;
+                aggregateAmount.BeneficialUseCategory = beneficialUsesCV.Name;
+                aggregateAmount.OrganizationUUID = organization.OrganizationUuid;
+                aggregateAmount.VariableSpecificUUID = variable.VariableSpecificUuid;
+                aggregateAmount.WaterSourceUUID = waterSource.WaterSourceUuid;
+                aggregateAmount.MethodUUID = method.MethodUuid;
+                aggregateAmount.DataPublicationDate = dataPublicationDate.Date;
+            }
+
+            var sut = CreateWaterAllocationAccessor();
+
+            var result = await sut.LoadAggregatedAmounts((new Faker()).Random.AlphaNumeric(10), new[] { aggregateAmount });
+
+            result.Should().BeTrue();
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                var dbAggregateAmount = await db.AggregatedAmountsFact.SingleAsync();
+                dbAggregateAmount.Should().NotBeNull();
+
+                dbAggregateAmount.PrimaryUseCategoryCV.Should().Be(primaryUseCategoryCV.Name);
+
+                var dbAggBridge = await db.AggBridgeBeneficialUsesFact.SingleAsync();
+                dbAggBridge.Should().NotBeNull();
+                dbAggBridge.AggBridgeId.Should().BeGreaterThan(0);
+                dbAggBridge.AggregatedAmountId.Should().Be(dbAggregateAmount.AggregatedAmountId);
+                dbAggBridge.BeneficialUseCV.Should().Be(beneficialUsesCV.Name);
 
                 db.ImportErrors.Should().HaveCount(0);
             }
@@ -383,7 +509,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 aggregateAmount = AggregatedAmountBuilder.Create();
 
                 aggregateAmount.PrimaryUseCategory = null;
-                
+
                 aggregateAmount.ReportingUnitUUID = reportingUnit.ReportingUnitUuid;
                 aggregateAmount.BeneficialUseCategory = beneficialUsesCV.Name;
                 aggregateAmount.OrganizationUUID = organization.OrganizationUuid;
@@ -394,7 +520,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             }
 
             var sut = CreateWaterAllocationAccessor();
-            
+
             var result = await sut.LoadAggregatedAmounts((new Faker()).Random.AlphaNumeric(10), new[] { aggregateAmount });
 
             result.Should().BeTrue();
@@ -405,9 +531,12 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 dbAggregateAmount.Should().NotBeNull();
                 dbAggregateAmount.PrimaryUseCategoryCV.Should().BeNull();
 
-                var dbAllocationBridge = await db.AggBridgeBeneficialUsesFact.SingleAsync();
-                dbAllocationBridge.Should().NotBeNull();
-                
+                var dbAggBridge = await db.AggBridgeBeneficialUsesFact.SingleAsync();
+                dbAggBridge.Should().NotBeNull();
+                dbAggBridge.AggBridgeId.Should().BeGreaterThan(0);
+                dbAggBridge.AggregatedAmountId.Should().Be(dbAggregateAmount.AggregatedAmountId);
+                dbAggBridge.BeneficialUseCV.Should().Be(beneficialUsesCV.Name);
+
                 db.ImportErrors.Should().HaveCount(0);
             }
         }

--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/004/011 Core.LoadWaterAllocation Null PrimaryUseCategory.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/004/011 Core.LoadWaterAllocation Null PrimaryUseCategory.sql
@@ -61,16 +61,17 @@ BEGIN
 		SELECT 'DataPublicationDate Not Valid' Reason, *
 		FROM #TempJoinedWaterAllocationData
 		WHERE DataPublicationDate IS NULL
-		UNION ALL
-		SELECT 'AllocationPriorityDate Not Valid' Reason, *
-		FROM #TempJoinedWaterAllocationData
-		WHERE AllocationPriorityDate IS NULL
 		--//////////////////////////////s
 		UNION ALL
 		SELECT 'Cross Group Not Valid' Reason, *
         FROM #TempJoinedWaterAllocationData
         WHERE CategoryCount >1
 		--//////////////////////////////////e
+		UNION ALL
+		SELECT 'Allocation Not Exempt of Volume Flow Priority' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE (ExemptOfVolumeFlowPriority IS NULL OR ExemptOfVolumeFlowPriority = 0) AND 
+			  (AllocationFlow_CFS IS NULL OR AllocationVolume_AF IS NULL OR AllocationPriorityDate IS NULL)
 	)
 	SELECT * INTO #TempErrorWaterAllocationRecords FROM q1;
 
@@ -173,8 +174,8 @@ BEGIN
 			,wad.AllocationTimeframeStart
 			,wad.AllocationTimeframeEnd
 			,wad.AllocationCropDutyAmount
-			,wad.AllocationAmount
-			,wad.AllocationMaximum
+			,wad.AllocationFlow_CFS
+			,wad.AllocationVolume_AF
 			,wad.PopulationServed
 			,wad.GeneratedPowerCapacityMW
 			,wad.IrrigatedAcreage
@@ -190,6 +191,7 @@ BEGIN
 			,wad.IrrigationMethodCV
 			,wad.CommunityWaterSupplySystem
 			,wad.PowerType
+			,wad.ExemptOfVolumeFlowPriority
 		FROM
 			#TempJoinedWaterAllocationData wad
 			--LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = wad.PrimaryUseCategory
@@ -224,8 +226,8 @@ BEGIN
 		,AllocationTimeframeStart
 		,AllocationTimeframeEnd
 		,AllocationCropDutyAmount
-		,AllocationAmount
-		,AllocationMaximum
+		,AllocationFlow_CFS
+		,AllocationVolume_AF
 		,PopulationServed
 		,GeneratedPowerCapacityMW
 		,IrrigatedAcreage
@@ -239,7 +241,8 @@ BEGIN
 		,CustomerTypeCV
 		,IrrigationMethodCV
 		,CommunityWaterSupplySystem
-		,PowerType)
+		,PowerType
+		,ExemptOfVolumeFlowPriority)
 	VALUES
 		(Source.OrganizationID
 		,Source.VariableSpecificID
@@ -259,8 +262,8 @@ BEGIN
 		,Source.AllocationTimeframeStart
 		,Source.AllocationTimeframeEnd
 		,Source.AllocationCropDutyAmount
-		,Source.AllocationAmount
-		,Source.AllocationMaximum
+		,Source.AllocationFlow_CFS
+		,Source.AllocationVolume_AF
 		,Source.PopulationServed
 		,Source.GeneratedPowerCapacityMW
 		,Source.IrrigatedAcreage
@@ -274,7 +277,8 @@ BEGIN
 		,Source.CustomerType
 		,Source.IrrigationMethodCV
 		,Source.CommunityWaterSupplySystem
-		,Source.PowerType)
+		,Source.PowerType
+		,Source.ExemptOfVolumeFlowPriority)
 	WHEN MATCHED THEN
 	  UPDATE SET
 		OrganizationID = Source.OrganizationID,
@@ -295,8 +299,8 @@ BEGIN
 		AllocationTimeframeStart = Source.AllocationTimeframeStart,
 		AllocationTimeframeEnd = Source.AllocationTimeframeEnd,
 		AllocationCropDutyAmount = Source.AllocationCropDutyAmount,
-		AllocationAmount = Source.AllocationAmount,
-		AllocationMaximum = Source.AllocationMaximum,
+		AllocationFlow_CFS = Source.AllocationFlow_CFS,
+		AllocationVolume_AF = Source.AllocationVolume_AF,
 		PopulationServed = Source.PopulationServed,
 		GeneratedPowerCapacityMW = Source.GeneratedPowerCapacityMW,
 		IrrigatedAcreage = Source.IrrigatedAcreage,
@@ -310,7 +314,8 @@ BEGIN
 		CustomerTypeCV = Source.CustomerType,
 		IrrigationMethodCV = Source.IrrigationMethodCV,
 		CommunityWaterSupplySystem = Source.CommunityWaterSupplySystem,
-		PowerType = Source.PowerType		
+		PowerType = Source.PowerType,
+		ExemptOfVolumeFlowPriority = Source.ExemptOfVolumeFlowPriority
 	OUTPUT
 		inserted.AllocationAmountID
 		,Source.RowNumber

--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/004/011. Core.LoadWaterAllocation Null PrimaryUseCategory.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/004/011. Core.LoadWaterAllocation Null PrimaryUseCategory.sql
@@ -1,0 +1,348 @@
+﻿SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+ALTER PROCEDURE [Core].[LoadWaterAllocation]
+(
+	@RunId nvarchar(250),
+	@WaterAllocationTable Core.WaterAllocationTableType READONLY
+)
+AS
+BEGIN
+	SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) RowNumber, *
+	INTO #TempWaterAllocationData
+	FROM @WaterAllocationTable;
+
+	--wire up the foreign keys
+	SELECT
+		wad.*
+		,o.OrganizationID
+		,v.VariableSpecificID
+		,ws.WaterSourceID
+		,m.MethodID
+		,bs.Name PrimaryUseCategoryCV
+		,CASE WHEN PopulationServed IS NULL AND CommunityWaterSupplySystem IS NULL 
+						AND CustomerType IS NULL AND AllocationSDWISIdentifier IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN IrrigatedAcreage IS NULL AND CropTypeCV IS NULL 
+						AND IrrigationMethodCV IS NULL AND AllocationCropDutyAmount IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN GeneratedPowerCapacityMW IS NULL AND PowerType IS NULL
+						THEN 0 ELSE 1 END CategoryCount
+	INTO
+		#TempJoinedWaterAllocationData
+	FROM
+		#TempWaterAllocationData wad
+		LEFT OUTER JOIN Core.Organizations_dim o ON o.OrganizationUUID = wad.OrganizationUUID
+		LEFT OUTER JOIN Core.Variables_dim v ON v.VariableSpecificUUID = wad.VariableSpecificUUID
+		LEFT OUTER JOIN Core.WaterSources_dim ws ON ws.WaterSourceUUID = wad.WaterSourceUUID
+		LEFT OUTER JOIN CVs.BeneficialUses bs ON bs.Name=wad.PrimaryUseCategory
+		LEFT OUTER JOIN Core.Methods_dim m ON m.MethodUUID = wad.MethodUUID;
+		
+	--data validation
+	WITH q1 AS
+	(
+		SELECT 'OrganizationID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE OrganizationID IS NULL
+		UNION ALL
+		SELECT 'VariableSpecificID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE VariableSpecificID IS NULL
+		UNION ALL
+		SELECT 'WaterSourceID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE WaterSourceID IS NULL
+		UNION ALL
+		SELECT 'MethodID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE MethodID IS NULL
+		UNION ALL
+		SELECT 'DataPublicationDate Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE DataPublicationDate IS NULL
+		UNION ALL
+		SELECT 'AllocationPriorityDate Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE AllocationPriorityDate IS NULL
+		--//////////////////////////////s
+		UNION ALL
+		SELECT 'Cross Group Not Valid' Reason, *
+        FROM #TempJoinedWaterAllocationData
+        WHERE CategoryCount >1
+		--//////////////////////////////////e
+	)
+	SELECT * INTO #TempErrorWaterAllocationRecords FROM q1;
+
+	--if we have errors, insert them and bail out
+	IF EXISTS(SELECT 1 FROM #TempErrorWaterAllocationRecords) 
+	BEGIN
+		INSERT INTO Core.ImportErrors ([Type], [RunId], [Data])
+		VALUES ('WaterAllocations', @RunId, (SELECT * FROM #TempErrorWaterAllocationRecords FOR JSON PATH));
+		RETURN 1;
+	END
+
+	--set up missing Core.BeneficialUses_dim entries
+	SELECT
+		wad.RowNumber
+		,BeneficialUse = TRIM(bu.[Value]) 
+	INTO
+		#TempBeneficialUsesData
+	FROM
+		#TempWaterAllocationData wad
+		CROSS APPLY STRING_SPLIT(wad.BeneficialUseCategory, ',') bu
+	WHERE
+		bu.[Value] IS NOT NULL
+		AND LEN(TRIM(bu.[Value])) > 0;
+
+	--INSERT INTO
+	--	CVs.BeneficialUses(Name)
+ --   SELECT DISTINCT
+	--	bud.BeneficialUse
+ --   FROM
+	--	#TempBeneficialUsesData bud
+	--	LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = bud.BeneficialUse
+ --     WHERE
+	--	bu.Name IS NULL;
+
+	--INSERT INTO
+	--	CVs.BeneficialUses(Name)
+	--SELECT DISTINCT
+	--	wad.PrimaryUseCategory
+	--FROM
+	--	#TempWaterAllocationData wad
+	--	LEFT OUTER JOIN CVs.BeneficialUses bu on bu.Name = wad.PrimaryUseCategory
+	--WHERE
+	--	bu.Name IS NULL
+	--	AND wad.PrimaryUseCategory IS NOT NULL
+	--	AND LEN(TRIM(wad.PrimaryUseCategory)) > 0;
+
+	--set up missing Core.Sites_dim entries
+	SELECT
+		wad.RowNumber
+		,SiteUUID = TRIM(s.[Value]) 
+	INTO
+		#TempSitesData
+	FROM
+		#TempWaterAllocationData wad
+		CROSS APPLY STRING_SPLIT(wad.SiteUUID, ',') s
+	WHERE
+		s.[Value] IS NOT NULL
+		AND LEN(TRIM(s.[Value])) > 0;
+
+	--set up missing Core.Date_dim entries
+	WITH q1 AS
+	(
+		SELECT [Date]
+		FROM #TempWaterAllocationData wad
+		UNPIVOT ([Date] FOR Dates IN (wad.DataPublicationDATE, wad.AllocationApplicationDate, wad.AllocationPriorityDate, wad.AllocationExpirationDate)) AS up
+	)
+	INSERT INTO Core.Date_dim (Date, Year)
+	SELECT
+		q1.[Date]
+		,YEAR(q1.[Date])
+	FROM
+		q1
+		LEFT OUTER JOIN Core.Date_dim d ON q1.[Date] = d.[Date]
+	WHERE
+        d.DateID IS NULL AND q1.[Date] IS NOT NULL
+    GROUP BY
+        q1.[Date];
+ 
+	--merge into Core.AllocationAmounts_fact
+	CREATE TABLE #AllocationAmountRecords(AllocationAmountID BIGINT, RowNumber BIGINT);
+
+	WITH q1 AS
+	(
+		SELECT
+			wad.OrganizationID
+			,wad.VariableSpecificID
+			,wad.WaterSourceID
+			,wad.MethodID
+			,wad.PrimaryUseCategory
+			,DataPublicationDateID = dpub.DateID
+			,wad.DataPublicationDOI
+			,wad.AllocationNativeID
+			,AllocationApplicationDate = dApp.DateID
+			,AllocationPriorityDate = dPri.DateID
+			,AllocationExpirationDate = dExp.DateID
+			,wad.AllocationOwner
+			,wad.AllocationBasisCV
+			,wad.AllocationLegalStatusCV
+			,wad.AllocationTypeCV
+			,wad.AllocationTimeframeStart
+			,wad.AllocationTimeframeEnd
+			,wad.AllocationCropDutyAmount
+			,wad.AllocationAmount
+			,wad.AllocationMaximum
+			,wad.PopulationServed
+			,wad.GeneratedPowerCapacityMW
+			,wad.IrrigatedAcreage
+			,wad.AllocationCommunityWaterSupplySystem
+			,wad.AllocationSDWISIdentifier
+			,wad.AllocationAssociatedWithdrawalSiteIDs
+			,wad.AllocationAssociatedConsumptiveUseSiteIDs
+			,wad.AllocationChangeApplicationIndicator
+			,wad.LegacyAllocationIDs
+			,wad.RowNumber
+			,wad.CropTypeCV
+			,wad.CustomerType
+			,wad.IrrigationMethodCV
+			,wad.CommunityWaterSupplySystem
+			,wad.PowerType
+		FROM
+			#TempJoinedWaterAllocationData wad
+			--LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = wad.PrimaryUseCategory
+			LEFT OUTER JOIN Core.Date_dim dPub ON dPub.[Date] = wad.DataPublicationDate
+			LEFT OUTER JOIN Core.Date_dim dApp ON dApp.[Date] = wad.AllocationApplicationDate
+			LEFT OUTER JOIN Core.Date_dim dPri ON dPri.[Date] = wad.AllocationPriorityDate
+			LEFT OUTER JOIN Core.Date_dim dExp ON dExp.[Date] = wad.AllocationExpirationDate
+	)
+	MERGE INTO Core.AllocationAmounts_fact AS Target
+	USING q1 AS Source ON
+		ISNULL(Target.OrganizationID, '') = ISNULL(Source.OrganizationID, '')
+		AND ISNULL(Target.AllocationNativeID, '') = ISNULL(Source.AllocationNativeID, '')
+		AND ISNULL(Target.VariableSpecificID, '') = ISNULL(Source.VariableSpecificID, '')
+		AND ISNULL(Target.PrimaryUseCategoryCV, '') = ISNULL(Source.PrimaryUseCategory, '')
+	WHEN NOT MATCHED THEN
+	INSERT
+		(OrganizationID
+		,VariableSpecificID
+		,WaterSourceID
+		,MethodID
+		,PrimaryUseCategoryCV
+		,DataPublicationDateID
+		,DataPublicationDOI
+		,AllocationNativeID
+		,AllocationApplicationDateID
+		,AllocationPriorityDateID
+		,AllocationExpirationDateID
+		,AllocationOwner
+		,AllocationBasisCV
+		,AllocationLegalStatusCV
+		,AllocationTypeCV
+		,AllocationTimeframeStart
+		,AllocationTimeframeEnd
+		,AllocationCropDutyAmount
+		,AllocationAmount
+		,AllocationMaximum
+		,PopulationServed
+		,GeneratedPowerCapacityMW
+		,IrrigatedAcreage
+		,AllocationCommunityWaterSupplySystem
+		,SDWISIdentifierCV
+		,AllocationAssociatedWithdrawalSiteIDs
+		,AllocationAssociatedConsumptiveUseSiteIDs
+		,AllocationChangeApplicationIndicator
+		,LegacyAllocationIDs
+		,CropTypeCV
+		,CustomerTypeCV
+		,IrrigationMethodCV
+		,CommunityWaterSupplySystem
+		,PowerType)
+	VALUES
+		(Source.OrganizationID
+		,Source.VariableSpecificID
+		,Source.WaterSourceID
+		,Source.MethodID
+		,Source.PrimaryUseCategory
+		,Source.DataPublicationDateID
+		,Source.DataPublicationDOI
+		,Source.AllocationNativeID
+		,Source.AllocationApplicationDate
+		,Source.AllocationPriorityDate
+		,Source.AllocationExpirationDate
+		,Source.AllocationOwner
+		,Source.AllocationBasisCV
+		,Source.AllocationLegalStatusCV
+		,Source.AllocationTypeCV
+		,Source.AllocationTimeframeStart
+		,Source.AllocationTimeframeEnd
+		,Source.AllocationCropDutyAmount
+		,Source.AllocationAmount
+		,Source.AllocationMaximum
+		,Source.PopulationServed
+		,Source.GeneratedPowerCapacityMW
+		,Source.IrrigatedAcreage
+		,Source.AllocationCommunityWaterSupplySystem
+		,Source.AllocationSDWISIdentifier
+		,Source.AllocationAssociatedWithdrawalSiteIDs
+		,Source.AllocationAssociatedConsumptiveUseSiteIDs
+		,Source.AllocationChangeApplicationIndicator
+		,Source.LegacyAllocationIDs
+		,Source.CropTypeCV
+		,Source.CustomerType
+		,Source.IrrigationMethodCV
+		,Source.CommunityWaterSupplySystem
+		,Source.PowerType)
+	WHEN MATCHED THEN
+	  UPDATE SET
+		OrganizationID = Source.OrganizationID,
+		VariableSpecificID = Source.VariableSpecificID,
+		WaterSourceID = Source.WaterSourceID,
+		MethodID = Source.MethodID,
+		PrimaryUseCategoryCV = Source.PrimaryUseCategory,
+		DataPublicationDateID = Source.DataPublicationDateID,
+		DataPublicationDOI = Source.DataPublicationDOI,
+		AllocationNativeID = Source.AllocationNativeID,
+		AllocationApplicationDateID = Source.AllocationApplicationDate,
+		AllocationPriorityDateID = Source.AllocationPriorityDate,
+		AllocationExpirationDateID = Source.AllocationExpirationDate,
+		AllocationOwner = Source.AllocationOwner,
+		AllocationBasisCV = Source.AllocationBasisCV,
+		AllocationLegalStatusCV = Source.AllocationLegalStatusCV,
+		AllocationTypeCV = Source.AllocationTypeCV,
+		AllocationTimeframeStart = Source.AllocationTimeframeStart,
+		AllocationTimeframeEnd = Source.AllocationTimeframeEnd,
+		AllocationCropDutyAmount = Source.AllocationCropDutyAmount,
+		AllocationAmount = Source.AllocationAmount,
+		AllocationMaximum = Source.AllocationMaximum,
+		PopulationServed = Source.PopulationServed,
+		GeneratedPowerCapacityMW = Source.GeneratedPowerCapacityMW,
+		IrrigatedAcreage = Source.IrrigatedAcreage,
+		AllocationCommunityWaterSupplySystem = Source.AllocationCommunityWaterSupplySystem,
+		SDWISIdentifierCV = Source.AllocationSDWISIdentifier,
+		AllocationAssociatedWithdrawalSiteIDs = Source.AllocationAssociatedWithdrawalSiteIDs,
+		AllocationAssociatedConsumptiveUseSiteIDs = Source.AllocationAssociatedConsumptiveUseSiteIDs,
+		AllocationChangeApplicationIndicator = Source.AllocationChangeApplicationIndicator,
+		LegacyAllocationIDs = Source.LegacyAllocationIDs,
+		CropTypeCV = Source.CropTypeCV,
+		CustomerTypeCV = Source.CustomerType,
+		IrrigationMethodCV = Source.IrrigationMethodCV,
+		CommunityWaterSupplySystem = Source.CommunityWaterSupplySystem,
+		PowerType = Source.PowerType		
+	OUTPUT
+		inserted.AllocationAmountID
+		,Source.RowNumber
+	INTO
+		#AllocationAmountRecords;
+
+	
+	--insert into Core.AllocationBridge_BeneficialUses_fact
+	INSERT INTO Core.AllocationBridge_BeneficialUses_fact (BeneficialUseCV, AllocationAmountID)
+	SELECT DISTINCT
+		bu.Name
+		,aar.AllocationAmountID
+	FROM
+		#AllocationAmountRecords aar
+		LEFT OUTER JOIN #TempBeneficialUsesData bud ON bud.RowNumber = aar.RowNumber
+		LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = bud.BeneficialUse
+	WHERE
+		bu.Name IS NOT NULL AND
+		NOT EXISTS(SELECT 1 from Core.AllocationBridge_BeneficialUses_fact innerAB where innerAB.AllocationAmountID = aar.AllocationAmountID and innerAB.BeneficialUseCV = bu.Name);
+
+	--insert into Core.AllocationBridge_Sites_fact
+	INSERT INTO Core.AllocationBridge_Sites_fact (SiteID, AllocationAmountID)
+	SELECT DISTINCT
+		s.SiteID
+		,aar.AllocationAmountID
+	FROM
+		#AllocationAmountRecords aar
+		LEFT OUTER JOIN #TempSitesData siteData ON siteData.RowNumber = aar.RowNumber
+		LEFT OUTER JOIN Sites_dim s ON s.SiteUUID = siteData.SiteUUID
+	WHERE
+		s.SiteID IS NOT NULL AND
+		NOT EXISTS(SELECT 1 from Core.AllocationBridge_Sites_fact innerAB where innerAB.AllocationAmountID = aar.AllocationAmountID and innerAB.SiteID = s.SiteID);
+	RETURN 0;
+
+END

--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/004/012 Core.LoadAggregatedAmounts Null PrimaryUseCategory.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/004/012 Core.LoadAggregatedAmounts Null PrimaryUseCategory.sql
@@ -1,0 +1,297 @@
+﻿SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+ALTER PROCEDURE [Core].[LoadAggregatedAmounts]
+(
+    @RunId NVARCHAR(250),
+    @AggregatedAmountTable Core.AggregatedAmountTableType READONLY
+)
+AS
+BEGIN
+    SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) RowNumber, *
+    INTO #TempAggregatedAmountData
+    FROM @AggregatedAmountTable;
+    
+    --wire up the foreign keys
+    SELECT
+        aad.*
+        ,og.OrganizationID
+		,ru.ReportingUnitID
+		,vb.VariableSpecificID
+		,mt.MethodID
+        ,wt.WaterSourceID
+		,bs.Name PrimaryUseCategoryCV
+		,CASE WHEN PopulationServed IS NULL AND CommunityWaterSupplySystem IS NULL 
+						AND CustomerType IS NULL AND SDWISIdentifier IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN IrrigatedAcreage IS NULL AND CropTypeCV IS NULL 
+						AND IrrigationMethodCV IS NULL AND AllocationCropDutyAmount IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN PowerGeneratedGWh IS NULL AND PowerType IS NULL
+						THEN 0 ELSE 1 END CategoryCount
+	INTO
+		#TempJoinedAggregatedAmountData
+    FROM
+        #TempAggregatedAmountData aad
+		LEFT OUTER JOIN Core.Organizations_dim og ON aad.OrganizationUUID = og.OrganizationUUID
+		LEFT OUTER JOIN Core.ReportingUnits_dim ru ON aad.ReportingUnitUUID = ru.ReportingUnitUUID
+        LEFT OUTER JOIN Core.Variables_dim vb ON aad.VariableSpecificUUID = vb.VariableSpecificUUID
+        LEFT OUTER JOIN Core.Methods_dim mt ON aad.MethodUUID = mt.MethodUUID
+	    LEFT OUTER JOIN CVs.BeneficialUses bs ON aad.PrimaryUseCategory = bs.Name
+        LEFT OUTER JOIN Core.WaterSources_dim wt ON aad.WaterSourceUUID = wt.WaterSourceUUID;
+
+		
+    --data validation
+    WITH q1 AS
+    (
+        SELECT 'OrganizationID Not Valid' Reason, *
+        FROM #TempJoinedAggregatedAmountData
+        WHERE OrganizationID IS NULL
+        UNION ALL
+		SELECT 'ReportingUnitID Not Valid' Reason, *
+        FROM #TempJoinedAggregatedAmountData
+        WHERE ReportingUnitID IS NULL
+        UNION ALL
+        SELECT 'VariableSpecificID Not Valid' Reason, *
+        FROM #TempJoinedAggregatedAmountData
+        WHERE VariableSpecificID IS NULL
+		 UNION ALL
+		SELECT 'MethodID Not Valid' Reason, *
+        FROM #TempJoinedAggregatedAmountData
+        WHERE MethodID IS NULL
+        UNION ALL
+        SELECT 'WaterSourceID Not Valid' Reason, *
+        FROM #TempJoinedAggregatedAmountData
+        WHERE WaterSourceID IS NULL
+        UNION ALL
+		SELECT 'Amount Not Valid' Reason, *
+        FROM #TempJoinedAggregatedAmountData
+        WHERE Amount IS NULL
+		--//////////////////////////////s
+		UNION ALL
+		SELECT 'Cross Group Not Valid' Reason, *
+        FROM #TempJoinedAggregatedAmountData
+        WHERE CategoryCount > 1
+		--//////////////////////////////////e
+
+    )
+    SELECT * INTO #TempErrorAggregatedAmountRecords FROM q1;
+
+	
+    --if we have errors, insert them and bail out
+    IF EXISTS(SELECT 1 FROM #TempErrorAggregatedAmountRecords) 
+    BEGIN
+        INSERT INTO Core.ImportErrors ([Type], [RunId], [Data])
+        VALUES ('AggregatedAmounts', @RunId, (SELECT * FROM #TempErrorAggregatedAmountRecords FOR JSON PATH));
+        RETURN 1;
+    END
+
+	
+
+    --set up missing Core.BeneficialUses_dim entries
+    SELECT
+        aad.RowNumber
+        ,BeneficialUse = TRIM(bu.[Value])
+    INTO
+        #TempBeneficialUsesData
+    FROM
+        #TempAggregatedAmountData aad
+        CROSS APPLY STRING_SPLIT(aad.BeneficialUseCategory, ',') bu
+    WHERE
+        bu.[Value] IS NOT NULL
+        AND LEN(TRIM(bu.[Value])) > 0;
+    
+    --INSERT INTO
+    --    CVs.BeneficialUses(Name)
+    --SELECT DISTINCT
+    --    bud.BeneficialUse
+    --FROM
+    --    #TempBeneficialUsesData bud
+    --    LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = bud.BeneficialUse
+    --WHERE
+    --    bu.Name IS NULL;
+
+    --INSERT INTO
+    --    CVs.BeneficialUses(Name)
+    --SELECT DISTINCT
+    --    aad.PrimaryUseCategory
+    --FROM
+    --    #TempAggregatedAmountData aad
+    --    LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = aad.PrimaryUseCategory
+    --WHERE
+    --    bu.Name IS NULL
+    --    AND aad.PrimaryUseCategory IS NOT NULL
+    --    AND LEN(TRIM(aad.PrimaryUseCategory)) > 0;
+    
+    --set up missing Core.Date_dim entries
+    WITH q1 AS
+    (
+        SELECT
+            [Date]
+        FROM
+            #TempAggregatedAmountData aad
+            UNPIVOT ([Date] FOR Dates IN (aad.TimeframeStart, aad.TimeframeEnd, aad.DataPublicationDate)) AS up
+	)
+    INSERT INTO Core.Date_dim (Date, Year)
+    SELECT
+        q1.[Date]
+        ,YEAR(q1.[Date])
+    FROM
+        q1
+        LEFT OUTER JOIN Core.Date_dim d ON q1.[Date] = d.[Date]
+    WHERE
+        d.DateID IS NULL AND q1.Date IS NOT NULL
+    GROUP BY
+        q1.[Date];
+
+    --merge into Core.AggregatedAmounts_fact
+    CREATE TABLE #AggregatedAmountRecords(AggregatedAmountID BIGINT, RowNumber BIGINT);
+    
+    WITH q1 AS
+    (
+        SELECT
+            jaad.OrganizationID
+			,jaad.ReportingUnitID
+            ,jaad.VariableSpecificID
+            ,jaad.PrimaryUseCategory
+            ,jaad.WaterSourceID
+            ,jaad.MethodID
+            ,TimeframeStartID = ds.DateID
+            ,TimeframeEndID = de.DateID
+            ,DataPublicationDate = dp.DateID
+			,jaad.DataPublicationDOI
+            ,jaad.ReportYearCV
+            ,jaad.Amount
+            ,jaad.PopulationServed
+            ,jaad.PowerGeneratedGWh
+            ,jaad.IrrigatedAcreage
+            ,jaad.InterbasinTransferToID
+            ,jaad.InterbasinTransferFromID
+			,jaad.RowNumber
+			,jaad.AllocationCropDutyAmount
+			,jaad.CropTypeCV
+			,jaad.CustomerType
+			,jaad.IrrigationMethodCV
+			,jaad.CommunityWaterSupplySystem
+			,jaad.SDWISIdentifier
+			,jaad.PowerType			
+        FROM
+            #TempJoinedAggregatedAmountData jaad
+           -- LEFT OUTER JOIN CVs.BeneficialUses bu ON jaad.PrimaryUseCategory = bu.Name
+            LEFT OUTER JOIN Core.Date_dim ds ON jaad.TimeframeStart = ds.[Date]
+            LEFT OUTER JOIN Core.Date_dim de ON jaad.TimeframeEnd = de.[Date]
+            LEFT OUTER JOIN Core.Date_dim dp ON jaad.DataPublicationDate = dp.[Date]
+    )
+    MERGE INTO Core.AggregatedAmounts_fact AS Target
+	USING q1 AS Source ON
+		ISNULL(Target.OrganizationID, '') = ISNULL(Source.OrganizationID, '')
+		AND ISNULL(Target.WaterSourceID, '') = ISNULL(Source.WaterSourceID, '')
+		AND ISNULL(Target.VariableSpecificID, '') = ISNULL(Source.VariableSpecificID, '')
+		AND ISNULL(Target.TimeframeStartID, '') = ISNULL(Source.TimeframeStartID, '')
+		AND ISNULL(Target.TimeframeEndID, '') = ISNULL(Source.TimeframeEndID, '')
+		AND ISNULL(Target.ReportYearCV, '') = ISNULL(Source.ReportYearCV, '')
+		AND ISNULL(Target.PrimaryUseCategoryCV, '') = ISNULL(Source.PrimaryUseCategory, '')
+		AND ISNULL(Target.ReportingUnitID,'') = ISNULL(Source.ReportingUnitID,'')
+		AND ISNULL(Target.MethodID,'') = ISNULL(Source.MethodID,'')
+		
+	WHEN NOT MATCHED THEN
+		INSERT
+			(OrganizationID
+			,ReportingUnitID
+			,VariableSpecificID
+			,PrimaryUseCategoryCV
+			,WaterSourceID
+			,MethodID
+			,TimeframeStartID
+			,TimeframeEndID
+			,DataPublicationDateID
+			,DataPublicationDOI
+			,ReportYearCV
+			,Amount
+			,PopulationServed
+			,PowerGeneratedGWh
+			,IrrigatedAcreage
+			,InterbasinTransferToID
+			,InterbasinTransferFromID
+			,AllocationCropDutyAmount
+			,CropTypeCV
+			,CustomerTypeCV
+			,IrrigationMethodCV
+			,CommunityWaterSupplySystem
+			,SDWISIdentifierCV
+			,PowerType
+			)
+		VALUES
+			(Source.OrganizationID
+			,Source.ReportingUnitID
+			,Source.VariableSpecificID
+			,Source.PrimaryUseCategory
+			,Source.WaterSourceID
+			,Source.MethodID
+			,Source.TimeframeStartID
+			,Source.TimeframeEndID
+			,Source.DataPublicationDate
+			,Source.DataPublicationDOI
+			,Source.ReportYearCV
+			,Source.Amount
+			,Source.PopulationServed
+			,Source.PowerGeneratedGWh
+			,Source.IrrigatedAcreage
+			,Source.InterbasinTransferToID
+			,Source.InterbasinTransferFromID
+			,Source.AllocationCropDutyAmount
+			,Source.CropTypeCV
+			,Source.CustomerType
+			,Source.IrrigationMethodCV
+			,Source.CommunityWaterSupplySystem
+			,Source.SDWISIdentifier
+			,Source.PowerType
+			)
+        WHEN MATCHED THEN
+            UPDATE SET
+            OrganizationID = Source.OrganizationID,
+			ReportingUnitID = Source.ReportingUnitID,
+			VariableSpecificID = Source.VariableSpecificID,
+			PrimaryUseCategoryCV = Source.PrimaryUseCategory,
+			WaterSourceID = Source.WaterSourceID,
+			MethodID = Source.MethodID,
+			TimeframeStartID = Source.TimeframeStartID,
+			TimeframeEndID = Source.TimeframeEndID,
+			DataPublicationDateID = Source.DataPublicationDate,
+			DataPublicationDOI = Source.DataPublicationDOI,
+			ReportYearCV = Source.ReportYearCV,
+		    Amount = Source.Amount,
+			PopulationServed = Source.PopulationServed,
+			PowerGeneratedGWh = Source.PowerGeneratedGWh,
+			IrrigatedAcreage = Source.IrrigatedAcreage,
+			InterbasinTransferToID = Source.InterbasinTransferToID,
+			InterbasinTransferFromID = Source.InterbasinTransferFromID,
+			AllocationCropDutyAmount = Source.AllocationCropDutyAmount,
+			CropTypeCV = Source.CropTypeCV,
+			CustomerTypeCV = Source.CustomerType,
+			IrrigationMethodCV = Source.IrrigationMethodCV,
+			CommunityWaterSupplySystem = Source.CommunityWaterSupplySystem,
+			SDWISIdentifierCV = Source.SDWISIdentifier,
+			PowerType = Source.PowerType
+		OUTPUT
+			inserted.AggregatedAmountID
+			,Source.RowNumber
+		INTO
+			#AggregatedAmountRecords;
+    
+	--insert into Core.AggBridge_BeneficialUses_fact
+	INSERT INTO Core.AggBridge_BeneficialUses_fact (BeneficialUseCV, AggregatedAmountID)
+	SELECT DISTINCT
+		bu.Name
+		,aar.AggregatedAmountID
+	FROM
+		#AggregatedAmountRecords aar
+		LEFT OUTER JOIN #TempBeneficialUsesData bud ON bud.RowNumber = aar.RowNumber
+		LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = bud.BeneficialUse
+	WHERE
+		bu.Name IS NOT NULL AND
+        NOT EXISTS(SELECT 1 from Core.AggBridge_BeneficialUses_fact innerAB where innerAB.AggregatedAmountID = aar.AggregatedAmountID and innerAB.BeneficialUseCV = bu.Name);
+
+	RETURN 0;
+END

--- a/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
+++ b/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
@@ -107,7 +107,7 @@
     <None Remove="Scripts\004\008 Core.AllocationAmounts_fact ExemptOfVolumeFlowPriority.sql" />
     <None Remove="Scripts\004\009 Core.RegulatoryOverlay_dim Updates.sql" />
     <None Remove="Scripts\004\010 Core.Sites_dim Updates.sql" />
-    <None Remove="Scripts\004\011. Core.LoadWaterAllocation Null PrimaryUseCategory.sql" />
+    <None Remove="Scripts\004\011 Core.LoadWaterAllocation Null PrimaryUseCategory.sql" />
     <None Remove="Scripts\004\012 Core.LoadAggregatedAmounts Null PrimaryUseCategory.sql" />
     <None Remove="Scripts\005 Core.LoadOrganization.sql" />
     <None Remove="Scripts\006 Core.LoadRegulatoryOverlays.sql" />
@@ -369,7 +369,7 @@
     <EmbeddedResource Include="Scripts\004\006 Core.AllocationAmounts_fact Update AllocationOwner Size.sql" />
     <EmbeddedResource Include="Scripts\004\005 Core.AllocationAmounts_fact Rename AllocationMaximum.sql" />
     <EmbeddedResource Include="Scripts\004\012 Core.LoadAggregatedAmounts Null PrimaryUseCategory.sql" />
-    <EmbeddedResource Include="Scripts\004\011. Core.LoadWaterAllocation Null PrimaryUseCategory.sql" />
+    <EmbeddedResource Include="Scripts\004\011 Core.LoadWaterAllocation Null PrimaryUseCategory.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
+++ b/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
@@ -99,6 +99,8 @@
     <None Remove="Scripts\004 Core.LoadMethods.sql" />
     <None Remove="Scripts\004\001 CVs.RegulatoryOverlayType CreateTable.sql" />
     <None Remove="Scripts\004\002 CVs.WaDEName.sql" />
+    <None Remove="Scripts\004\011. Core.LoadWaterAllocation Null PrimaryUseCategory.sql" />
+    <None Remove="Scripts\004\012 Core.LoadAggregatedAmounts Null PrimaryUseCategory.sql" />
     <None Remove="Scripts\005 Core.LoadOrganization.sql" />
     <None Remove="Scripts\006 Core.LoadRegulatoryOverlays.sql" />
     <None Remove="Scripts\007 Core.LoadReportingUnits.sql" />
@@ -350,6 +352,8 @@
     <EmbeddedResource Include="Scripts\003\019 Core.LoadSiteSpecificAmounts AddPowerType.sql" />
     <EmbeddedResource Include="Scripts\004\001 CVs.RegulatoryOverlayType CreateTable.sql" />
     <EmbeddedResource Include="Scripts\004\002 CVs.WaDEName.sql" />
+    <EmbeddedResource Include="Scripts\004\012 Core.LoadAggregatedAmounts Null PrimaryUseCategory.sql" />
+    <EmbeddedResource Include="Scripts\004\011. Core.LoadWaterAllocation Null PrimaryUseCategory.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/AggregatedAmountBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/AggregatedAmountBuilder.cs
@@ -1,0 +1,33 @@
+﻿using Bogus;
+using WesternStatesWater.WaDE.Accessors.Contracts.Import;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Import
+{
+
+    public static class AggregatedAmountBuilder
+    {
+        public static AggregatedAmount Create()
+        {
+            return Create(new AggregatedAmountBuilderOptions());
+        }
+
+        public static AggregatedAmount Create(AggregatedAmountBuilderOptions opts)
+        {
+            var faker = new Faker<AggregatedAmount>()
+                .RuleFor(a => a.OrganizationUUID, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.VariableSpecificUUID, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.WaterSourceUUID, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.MethodUUID, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.DataPublicationDate, f => f.Date.Past(5))
+                .RuleFor(a => a.DataPublicationDOI, f => f.Random.Words(5))
+                .RuleFor(a => a.Amount, f => f.Random.Number(int.MaxValue).ToString())
+                ;
+
+            return faker;
+        }
+    }
+
+    public class AggregatedAmountBuilderOptions
+    {
+    }
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/BeneficalUsesBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/BeneficalUsesBuilder.cs
@@ -1,0 +1,49 @@
+﻿using Bogus;
+using System.Threading.Tasks;
+using WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
+{
+    public static class BeneficalUsesBuilder
+    {
+        public static BeneficialUsesCV Create()
+        {
+            return Create(new BeneficalUsesBuilderOptions());
+        }
+
+        public static BeneficialUsesCV Create(BeneficalUsesBuilderOptions opts)
+        {
+            return new Faker<BeneficialUsesCV>()
+                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Term, f => f.Random.Word())
+                .RuleFor(a => a.Definition, f => f.Random.Words(5))
+                .RuleFor(a => a.State, f => f.Address.StateAbbr())
+                .RuleFor(a => a.SourceVocabularyURI, f => f.Internet.Url());
+        }
+
+        public static async Task<BeneficialUsesCV> Load(WaDEContext db)
+        {
+            return await Load(db, new BeneficalUsesBuilderOptions());
+        }
+
+        public static async Task<BeneficialUsesCV> Load(WaDEContext db, BeneficalUsesBuilderOptions opts)
+        {
+            var item = Create(opts);
+
+            db.BeneficialUsesCV.Add(item);
+            await db.SaveChangesAsync();
+
+            return item;
+        }
+
+        public static string GenerateName()
+        {
+            return new Faker().Random.AlphaNumeric(50);
+        }
+    }
+
+    public class BeneficalUsesBuilderOptions
+    {
+
+    }
+}


### PR DESCRIPTION
* Removed the `PrimaryUseCategory IS NOT NULL` condition check from `#TempBeneficialUseData` table in LoadWaterAllocation and LoadAggregatedAmounts SPs.

Problem of CVs.BeneficialUses and Core.AggreatedBridge_BeneficialUses_facts tables not updating if the PrimaryUseCategory field in Core.AllowcatoinAmounts_facts is NULL.  This field should be optional and allow NULL fields, and still allow these tables to update.  Right now, if we load data that has NULL in the PrimaryUseCategory, then the table Core_AllocationBridge_BeneficialUses_fact does not get populated, which is a problem.