### PR TITLE
Updates to RegulatoryReportingUnit data loader and fixed Site Specific Amounts SP

### DIFF
--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Import/RegulatoryReportingUnits.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Import/RegulatoryReportingUnits.cs
@@ -6,15 +6,15 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Import
     public class RegulatoryReportingUnits
     {
         [NullValues("")]
-        public string OrganizationName { get; set; }
+        public string OrganizationUUID { get; set; }
 
         [NullValues("")]
-        public string RegulatoryOverlayName { get; set; }
+        public string RegulatoryOverlayUUID { get; set; }
 
         [NullValues("")]
-        public string ReportingUnitName { get; set; }
+        public string ReportingUnitUUID { get; set; }
 
         [NullValues("")]
-        public string DataPublicationDateID { get; set; }
+        public string DataPublicationDate { get; set; }
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/ImportWaterAllocationAccessorTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/ImportWaterAllocationAccessorTests.cs
@@ -671,23 +671,11 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 });
             }
 
-            // Civilian
-            siteSpecificAmount.PopulationServed.Should().BeNull();
-            siteSpecificAmount.CommunityWaterSupplySystem.Should().BeNull();
-            siteSpecificAmount.CustomerTypeCV.Should().BeNull();
-            siteSpecificAmount.SDWISIdentifier.Should().BeNull();
-            ////////////
-
             // Ag
             siteSpecificAmount.IrrigatedAcreage.Should().NotBeNullOrEmpty("Required field");
             siteSpecificAmount.CropTypeCV.Should().NotBeNullOrEmpty("Required field");
             siteSpecificAmount.IrrigationMethodCV.Should().NotBeNullOrEmpty("Required field");
             siteSpecificAmount.AllocationCropDutyAmount.Should().NotBeNullOrEmpty("Required field");
-
-            // Power
-            siteSpecificAmount.PowerGeneratedGWh.Should().BeNull();
-            siteSpecificAmount.PowerType.Should().BeNull();
-
 
             var sut = CreateWaterAllocationAccessor();
             var result = await sut.LoadSiteSpecificAmounts((new Faker()).Random.AlphaNumeric(10), new[] { siteSpecificAmount });

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/ImportWaterAllocationAccessorTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/ImportWaterAllocationAccessorTests.cs
@@ -547,7 +547,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
         }
 
         [TestMethod]
-        public async Task LoadSiteSpecificAmounts_SimpleLoad_Agriculture()
+        public async Task LoadSiteSpecificAmounts_SimpleLoad_Civilian()
         {
             OrganizationsDim organization;
             SitesDim site;
@@ -558,10 +558,9 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             BeneficialUsesCV beneficialUses;
             BeneficialUsesCV primaryUseCategory;
             ReportYearCv reportYear;
-            SDWISIdentifier sdwisIdentifier;
+            DateDim publicationDate;
             CustomerType customerType;
-            CropType cropType;
-            IrrigationMethod irrigationMethod;
+            SDWISIdentifier sdwisIdentifier;
 
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
@@ -573,24 +572,100 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 beneficialUses = await BeneficalUsesBuilder.Load(db);
                 primaryUseCategory = await BeneficalUsesBuilder.Load(db);
                 reportYear = await ReportYearCvBuilder.Load(db);
-                sdwisIdentifier = await SDWISIdentifierBuilder.Load(db);
+                publicationDate = await DateDimBuilder.Load(db);
                 customerType = await CustomerTypeBuilder.Load(db);
-                cropType = await CropTypeBuilder.Load(db);
-                irrigationMethod = await IrrigationMethodBuilder.Load(db);
+                sdwisIdentifier = await SDWISIdentifierBuilder.Load(db);
 
                 siteSpecificAmount = SiteSpecificAmountBuilder.Create(new SiteSpecificAmountBuilderOptions
                 {
-                    RecordType = SiteSpecificRecordType.Ag,
+                    RecordType = SiteSpecificRecordType.Civilian,
                     Method = method,
                     Organization = organization,
+                    DataPublicationDate = publicationDate,
                     Site = site,
                     Variable = variable,
                     WaterSource = waterSource,
                     BeneficialUse = beneficialUses,
                     PrimaryUseCategory = primaryUseCategory,
                     ReportYear = reportYear,
-                    SDWISIdentifier = sdwisIdentifier,
                     CustomerType = customerType,
+                    SDWISIdentifier = sdwisIdentifier
+                });
+            }
+
+            siteSpecificAmount.PopulationServed.Should().NotBeNullOrEmpty("Required field");
+            siteSpecificAmount.CommunityWaterSupplySystem.Should().NotBeNullOrEmpty("Required field");
+            siteSpecificAmount.CustomerTypeCV.Should().NotBeNullOrEmpty("Required field");
+            siteSpecificAmount.SDWISIdentifier.Should().NotBeNullOrEmpty("Required field");
+
+            var sut = CreateWaterAllocationAccessor();
+            var result = await sut.LoadSiteSpecificAmounts((new Faker()).Random.AlphaNumeric(10), new[] { siteSpecificAmount });
+
+            result.Should().BeTrue();
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                var dbSiteVariableAmount = await db.SiteVariableAmountsFact.SingleAsync();
+
+                dbSiteVariableAmount.OrganizationId.Should().Be(organization.OrganizationId);
+                dbSiteVariableAmount.SiteId.Should().Be(site.SiteId);
+                dbSiteVariableAmount.VariableSpecificId.Should().Be(variable.VariableSpecificId);
+                dbSiteVariableAmount.WaterSourceId.Should().Be(waterSource.WaterSourceId);
+                dbSiteVariableAmount.MethodId.Should().Be(method.MethodId);
+                dbSiteVariableAmount.PrimaryUseCategoryCV.Should().Be(primaryUseCategory.Name);
+                dbSiteVariableAmount.ReportYearCv.Should().Be(reportYear.Name);
+
+                dbSiteVariableAmount.PopulationServed.Should().Be(long.Parse(siteSpecificAmount.PopulationServed));
+                dbSiteVariableAmount.CommunityWaterSupplySystem.Should().Be(siteSpecificAmount.CommunityWaterSupplySystem);
+                dbSiteVariableAmount.CustomerTypeCv.Should().Be(customerType.Name);
+                dbSiteVariableAmount.SDWISIdentifierCv.Should().Be(sdwisIdentifier.Name);
+
+                db.ImportErrors.Should().HaveCount(0);
+            }
+        }
+
+        [TestMethod]
+        public async Task LoadSiteSpecificAmounts_SimpleLoad_Agriculture()
+        {
+            OrganizationsDim organization;
+            SitesDim site;
+            VariablesDim variable;
+            WaterSourcesDim waterSource;
+            MethodsDim method;
+            SiteSpecificAmount siteSpecificAmount;
+            BeneficialUsesCV beneficialUses;
+            BeneficialUsesCV primaryUseCategory;
+            ReportYearCv reportYear;
+            CropType cropType;
+            IrrigationMethod irrigationMethod;
+            DateDim publicationDate;
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                organization = await OrganizationsDimBuilder.Load(db);
+                site = await SitesDimBuilder.Load(db);
+                variable = await VariablesDimBuilder.Load(db);
+                waterSource = await WaterSourcesDimBuilder.Load(db);
+                method = await MethodsDimBuilder.Load(db);
+                beneficialUses = await BeneficalUsesBuilder.Load(db);
+                primaryUseCategory = await BeneficalUsesBuilder.Load(db);
+                reportYear = await ReportYearCvBuilder.Load(db);
+                cropType = await CropTypeBuilder.Load(db);
+                irrigationMethod = await IrrigationMethodBuilder.Load(db);
+                publicationDate = await DateDimBuilder.Load(db);
+
+                siteSpecificAmount = SiteSpecificAmountBuilder.Create(new SiteSpecificAmountBuilderOptions
+                {
+                    RecordType = SiteSpecificRecordType.Ag,
+                    Method = method,
+                    Organization = organization,
+                    DataPublicationDate = publicationDate,
+                    Site = site,
+                    Variable = variable,
+                    WaterSource = waterSource,
+                    BeneficialUse = beneficialUses,
+                    PrimaryUseCategory = primaryUseCategory,
+                    ReportYear = reportYear,
                     CropType = cropType,
                     IrrigationMethod = irrigationMethod
                 });
@@ -604,10 +679,10 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             ////////////
 
             // Ag
-            siteSpecificAmount.IrrigatedAcreage.Should().NotBeNullOrEmpty();
-            siteSpecificAmount.CropTypeCV.Should().NotBeNullOrEmpty();
-            siteSpecificAmount.IrrigationMethodCV.Should().NotBeNullOrEmpty();
-            siteSpecificAmount.AllocationCropDutyAmount.Should().NotBeNullOrEmpty();
+            siteSpecificAmount.IrrigatedAcreage.Should().NotBeNullOrEmpty("Required field");
+            siteSpecificAmount.CropTypeCV.Should().NotBeNullOrEmpty("Required field");
+            siteSpecificAmount.IrrigationMethodCV.Should().NotBeNullOrEmpty("Required field");
+            siteSpecificAmount.AllocationCropDutyAmount.Should().NotBeNullOrEmpty("Required field");
 
             // Power
             siteSpecificAmount.PowerGeneratedGWh.Should().BeNull();
@@ -623,8 +698,8 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             {
                 var dbSiteVariableAmount = await db.SiteVariableAmountsFact.SingleAsync();
 
-                dbSiteVariableAmount.OrganizationId.Should().NotBe(organization.OrganizationId);
-                dbSiteVariableAmount.Site.Should().Be(site.SiteId);
+                dbSiteVariableAmount.OrganizationId.Should().Be(organization.OrganizationId);
+                dbSiteVariableAmount.SiteId.Should().Be(site.SiteId);
                 dbSiteVariableAmount.VariableSpecificId.Should().Be(variable.VariableSpecificId);
                 dbSiteVariableAmount.WaterSourceId.Should().Be(waterSource.WaterSourceId);
                 dbSiteVariableAmount.MethodId.Should().Be(method.MethodId);
@@ -635,6 +710,77 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 dbSiteVariableAmount.CropTypeCv.Should().Be(cropType.Name);
                 dbSiteVariableAmount.IrrigationMethodCv.Should().Be(irrigationMethod.Name);
                 dbSiteVariableAmount.AllocationCropDutyAmount.Should().Be(double.Parse(siteSpecificAmount.AllocationCropDutyAmount));
+
+                db.ImportErrors.Should().HaveCount(0);
+            }
+        }
+
+        [TestMethod]
+        public async Task LoadSiteSpecificAmounts_SimpleLoad_Power()
+        {
+            OrganizationsDim organization;
+            SitesDim site;
+            VariablesDim variable;
+            WaterSourcesDim waterSource;
+            MethodsDim method;
+            SiteSpecificAmount siteSpecificAmount;
+            BeneficialUsesCV beneficialUses;
+            BeneficialUsesCV primaryUseCategory;
+            ReportYearCv reportYear;
+            DateDim publicationDate;
+            PowerType powerType;
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                organization = await OrganizationsDimBuilder.Load(db);
+                site = await SitesDimBuilder.Load(db);
+                variable = await VariablesDimBuilder.Load(db);
+                waterSource = await WaterSourcesDimBuilder.Load(db);
+                method = await MethodsDimBuilder.Load(db);
+                beneficialUses = await BeneficalUsesBuilder.Load(db);
+                primaryUseCategory = await BeneficalUsesBuilder.Load(db);
+                reportYear = await ReportYearCvBuilder.Load(db);
+                publicationDate = await DateDimBuilder.Load(db);
+                powerType = await PowerTypeBuilder.Load(db);
+
+                siteSpecificAmount = SiteSpecificAmountBuilder.Create(new SiteSpecificAmountBuilderOptions
+                {
+                    RecordType = SiteSpecificRecordType.Power,
+                    Method = method,
+                    Organization = organization,
+                    DataPublicationDate = publicationDate,
+                    Site = site,
+                    Variable = variable,
+                    WaterSource = waterSource,
+                    BeneficialUse = beneficialUses,
+                    PrimaryUseCategory = primaryUseCategory,
+                    ReportYear = reportYear,
+                    PowerType = powerType
+                });
+            }
+
+            siteSpecificAmount.PowerGeneratedGWh.Should().NotBeNullOrEmpty("Required field");
+            siteSpecificAmount.PowerType.Should().NotBeNullOrEmpty("Required field");
+
+            var sut = CreateWaterAllocationAccessor();
+            var result = await sut.LoadSiteSpecificAmounts((new Faker()).Random.AlphaNumeric(10), new[] { siteSpecificAmount });
+
+            result.Should().BeTrue();
+
+            using (var db = new WaDEContext(Configuration.GetConfiguration()))
+            {
+                var dbSiteVariableAmount = await db.SiteVariableAmountsFact.SingleAsync();
+
+                dbSiteVariableAmount.OrganizationId.Should().Be(organization.OrganizationId);
+                dbSiteVariableAmount.SiteId.Should().Be(site.SiteId);
+                dbSiteVariableAmount.VariableSpecificId.Should().Be(variable.VariableSpecificId);
+                dbSiteVariableAmount.WaterSourceId.Should().Be(waterSource.WaterSourceId);
+                dbSiteVariableAmount.MethodId.Should().Be(method.MethodId);
+                dbSiteVariableAmount.PrimaryUseCategoryCV.Should().Be(primaryUseCategory.Name);
+                dbSiteVariableAmount.ReportYearCv.Should().Be(reportYear.Name);
+
+                dbSiteVariableAmount.PowerGeneratedGwh.Should().Be(double.Parse(siteSpecificAmount.PowerGeneratedGWh));
+                dbSiteVariableAmount.PowerType.Should().Be(powerType.Name);
 
                 db.ImportErrors.Should().HaveCount(0);
             }

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/local.settings.json
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/local.settings.json
@@ -2,5 +2,8 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true"
+  },
+  "ConnectionStrings": {
+    "WadeDatabase": "Server=.;Initial Catalog=WaDE2Test;Integrated Security=true;"
   }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AggregatedAmountsFact.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AggregatedAmountsFact.cs
@@ -41,7 +41,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
         public double? AllocationCropDutyAmount { get; set; }
 
-        public string PowerTypeCV { get; set; }
+        public string PowerType { get; set; }
 
         public virtual BeneficialUsesCV PrimaryBeneficialUse { get; set; }
         public virtual DateDim DataPublicationDateNavigation { get; set; }
@@ -58,7 +58,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public virtual CustomerType CustomerType { get; set; }
         public virtual SDWISIdentifier SDWISIdentifier { get; set; }
         public virtual CropType CropType { get; set; }
-        public virtual PowerType PowerType { get; set; }
+        public virtual PowerType PowerTypeCV { get; set; }
         public virtual ICollection<AggBridgeBeneficialUsesFact> AggBridgeBeneficialUsesFact { get; set; }
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AggregatedAmountsFact.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AggregatedAmountsFact.cs
@@ -41,6 +41,8 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
         public double? AllocationCropDutyAmount { get; set; }
 
+        public string PowerTypeCV { get; set; }
+
         public virtual BeneficialUsesCV PrimaryBeneficialUse { get; set; }
         public virtual DateDim DataPublicationDateNavigation { get; set; }
         public virtual MethodsDim Method { get; set; }
@@ -56,6 +58,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public virtual CustomerType CustomerType { get; set; }
         public virtual SDWISIdentifier SDWISIdentifier { get; set; }
         public virtual CropType CropType { get; set; }
+        public virtual PowerType PowerType { get; set; }
         public virtual ICollection<AggBridgeBeneficialUsesFact> AggBridgeBeneficialUsesFact { get; set; }
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AllocationAmountsFact.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AllocationAmountsFact.cs
@@ -49,7 +49,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public string CustomerTypeCV { get; set; }
         public string CommunityWaterSupplySystem { get; set; }
         public bool? ExemptOfVolumeFlowPriority { get; set; }
-        public string PowerTypeCV { get; set; }
+        public string PowerType { get; set; }
 
         public virtual DateDim AllocationApplicationDateNavigation { get; set; }
         public virtual WaterAllocationBasis AllocationBasisCvNavigation { get; set; }
@@ -67,7 +67,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public virtual CustomerType CustomerType { get; set; }
         public virtual SDWISIdentifier SDWISIdentifier { get; set; }
         public virtual IrrigationMethod IrrigationMethod { get; set; }
-        public virtual PowerType PowerType { get; set; }
+        public virtual PowerType PowerTypeCV { get; set; }
         public virtual ICollection<AllocationBridgeBeneficialUsesFact> AllocationBridgeBeneficialUsesFact { get; set; }
         public virtual ICollection<AllocationBridgeSitesFact> AllocationBridgeSitesFact { get; set;}
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AllocationAmountsFact.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AllocationAmountsFact.cs
@@ -49,6 +49,8 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public string CustomerTypeCV { get; set; }
         public string CommunityWaterSupplySystem { get; set; }
         public bool? ExemptOfVolumeFlowPriority { get; set; }
+        public string PowerTypeCV { get; set; }
+
         public virtual DateDim AllocationApplicationDateNavigation { get; set; }
         public virtual WaterAllocationBasis AllocationBasisCvNavigation { get; set; }
         public virtual DateDim AllocationExpirationDateNavigation { get; set; }
@@ -65,6 +67,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public virtual CustomerType CustomerType { get; set; }
         public virtual SDWISIdentifier SDWISIdentifier { get; set; }
         public virtual IrrigationMethod IrrigationMethod { get; set; }
+        public virtual PowerType PowerType { get; set; }
         public virtual ICollection<AllocationBridgeBeneficialUsesFact> AllocationBridgeBeneficialUsesFact { get; set; }
         public virtual ICollection<AllocationBridgeSitesFact> AllocationBridgeSitesFact { get; set;}
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/PowerType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/PowerType.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace WesternStatesWater.WaDE.Accessors.EntityFramework
+{
+    public partial class PowerType
+    {
+        public PowerType()
+        {
+            SiteVariableAmountsFact = new HashSet<SiteVariableAmountsFact>();
+            AllocationAmountsFact = new HashSet<AllocationAmountsFact>();
+            AggregatedAmountsFact = new HashSet<AggregatedAmountsFact>();
+        }
+
+        public string Name { get; set; }
+        public string Term { get; set; }
+        public string Definition { get; set; }
+        public string State { get; set; }
+        public string SourceVocabularyUri { get; set; }
+
+        public virtual ICollection<SiteVariableAmountsFact> SiteVariableAmountsFact { get; set; }
+        public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }
+
+        public virtual ICollection<AggregatedAmountsFact> AggregatedAmountsFact { get; set; }
+
+
+    }
+}

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/SiteVariableAmountsFact.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/SiteVariableAmountsFact.cs
@@ -34,6 +34,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public IGeometry Geometry { get; set; }
         public string PrimaryUseCategoryCV { get; set; }
         public double? AllocationCropDutyAmount { get; set; }
+        public string PowerType { get; set; }
 
         public virtual BeneficialUsesCV PrimaryBeneficialUse { get; set; }
         public virtual CropType CropTypeCvNavigation { get; set; }
@@ -49,6 +50,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public virtual DateDim TimeframeStartNavigation { get; set; }
         public virtual VariablesDim VariableSpecific { get; set; }
         public virtual WaterSourcesDim WaterSource { get; set; }
+        public virtual PowerType PowerTypeCV { get; set; }
         public virtual ICollection<SitesBridgeBeneficialUsesFact> SitesBridgeBeneficialUsesFact { get; set; }
         
 

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
@@ -152,8 +152,8 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                   .HasColumnName("CommunityWaterSupplySystem")
                   .HasMaxLength(250);
 
-                entity.Property(e => e.PowerTypeCV)
-                    .HasColumnName("PowerTypeCV")
+                entity.Property(e => e.PowerType)
+                    .HasColumnName("PowerType")
                     .HasMaxLength(50);
 
                 entity.Property(e => e.TimeframeEndId).HasColumnName("TimeframeStartID");
@@ -272,9 +272,9 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                        .OnDelete(DeleteBehavior.ClientSetNull)
                        .HasConstraintName("fk_AggregatedAmounts_fact_SDWISIdentifier");
 
-                entity.HasOne(d => d.PowerType)
+                entity.HasOne(d => d.PowerTypeCV)
                     .WithMany(p => p.AggregatedAmountsFact)
-                    .HasForeignKey(d => d.PowerTypeCV)
+                    .HasForeignKey(d => d.PowerType)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("fk_AggregatedAmounts_fact_PowerTypeCV");
             });
@@ -382,8 +382,8 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                                    .HasColumnName("IrrigationMethodCV")
                                    .HasMaxLength(100);
 
-                entity.Property(e => e.PowerTypeCV)
-                    .HasColumnName("PowerTypeCV")
+                entity.Property(e => e.PowerType)
+                    .HasColumnName("PowerType")
                     .HasMaxLength(50);
 
                 ///////////////////////////////////////////////////////////////////////////////
@@ -501,9 +501,9 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                        .OnDelete(DeleteBehavior.ClientSetNull)
                        .HasConstraintName("fk_AllocationAmounts_fact_SDWISIdentifier");
                 
-                entity.HasOne(d => d.PowerType)
+                entity.HasOne(d => d.PowerTypeCV)
                     .WithMany(p => p.AllocationAmountsFact)
-                    .HasForeignKey(d => d.PowerTypeCV)
+                    .HasForeignKey(d => d.PowerType)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("fk_AllocationAmounts_fact_PowerTypeCV");
             });

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
@@ -38,6 +38,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public virtual DbSet<NhdnetworkStatus> NhdnetworkStatus { get; set; }
         public virtual DbSet<Nhdproduct> Nhdproduct { get; set; }
         public virtual DbSet<OrganizationsDim> OrganizationsDim { get; set; }
+        public virtual DbSet<PowerType> PowerType { get; set; }
         public virtual DbSet<RegulatoryOverlayDim> RegulatoryOverlayDim { get; set; }
         public virtual DbSet<RegulatoryOverlayType> RegulatoryOverlayType { get; set; }
         public virtual DbSet<RegulatoryReportingUnitsFact> RegulatoryReportingUnitsFact { get; set; }
@@ -150,6 +151,10 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                 entity.Property(e => e.CommunityWaterSupplySystem)
                   .HasColumnName("CommunityWaterSupplySystem")
                   .HasMaxLength(250);
+
+                entity.Property(e => e.PowerTypeCV)
+                    .HasColumnName("PowerTypeCV")
+                    .HasMaxLength(50);
 
                 entity.Property(e => e.TimeframeEndId).HasColumnName("TimeframeStartID");
 
@@ -267,7 +272,11 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                        .OnDelete(DeleteBehavior.ClientSetNull)
                        .HasConstraintName("fk_AggregatedAmounts_fact_SDWISIdentifier");
 
-
+                entity.HasOne(d => d.PowerType)
+                    .WithMany(p => p.AggregatedAmountsFact)
+                    .HasForeignKey(d => d.PowerTypeCV)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("fk_AggregatedAmounts_fact_PowerTypeCV");
             });
 
             modelBuilder.Entity<AggregationStatistic>(entity =>
@@ -372,6 +381,10 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                 entity.Property(e => e.IrrigationMethodCV)
                                    .HasColumnName("IrrigationMethodCV")
                                    .HasMaxLength(100);
+
+                entity.Property(e => e.PowerTypeCV)
+                    .HasColumnName("PowerTypeCV")
+                    .HasMaxLength(50);
 
                 ///////////////////////////////////////////////////////////////////////////////
 
@@ -487,7 +500,12 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                        .HasForeignKey(d => d.SdwisidentifierCV)
                        .OnDelete(DeleteBehavior.ClientSetNull)
                        .HasConstraintName("fk_AllocationAmounts_fact_SDWISIdentifier");
-
+                
+                entity.HasOne(d => d.PowerType)
+                    .WithMany(p => p.AllocationAmountsFact)
+                    .HasForeignKey(d => d.PowerTypeCV)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("fk_AllocationAmounts_fact_PowerTypeCV");
             });
 
             modelBuilder.Entity<AllocationBridgeBeneficialUsesFact>(entity =>
@@ -1029,6 +1047,28 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                     .HasMaxLength(250);
             });
 
+            modelBuilder.Entity<PowerType>(entity =>
+            {
+                entity.HasKey(e => e.Name)
+                    .HasName("PK_CVs.PowerType");
+
+                entity.ToTable("PowerType", "CVs");
+
+                entity.Property(e => e.Name)
+                    .HasMaxLength(50)
+                    .ValueGeneratedNever();
+
+                entity.Property(e => e.Definition).HasMaxLength(4000);
+
+                entity.Property(e => e.SourceVocabularyUri)
+                    .HasColumnName("SourceVocabularyURI")
+                    .HasMaxLength(250);
+
+                entity.Property(e => e.State).HasMaxLength(250);
+
+                entity.Property(e => e.Term).HasMaxLength(250);
+            });
+
             modelBuilder.Entity<RegulatoryOverlayDim>(entity =>
             {
                 entity.HasKey(e => e.RegulatoryOverlayId)
@@ -1374,6 +1414,10 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                     .HasColumnName("IrrigationMethodCV")
                     .HasMaxLength(100);
 
+                entity.Property(e => e.PowerType)
+                    .HasColumnName("PowerType")
+                    .HasMaxLength(50);
+
                 entity.Property(e => e.MethodId).HasColumnName("MethodID");
 
                 ///////////////////////////////////////////////////////////////
@@ -1485,6 +1529,12 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                    .HasForeignKey(d => d.SDWISIdentifierCv)
                    .OnDelete(DeleteBehavior.ClientSetNull)
                    .HasConstraintName("fk_SiteVariableAmounts_fact_SDWISIdentifier");
+
+                entity.HasOne(d => d.PowerTypeCV)
+                    .WithMany(p => p.SiteVariableAmountsFact)
+                    .HasForeignKey(d => d.PowerType)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("fk_SiteVariableAmounts_fact_PowerTypeCV");
             });
 
             modelBuilder.Entity<SitesBridgeBeneficialUsesFact>(entity =>

--- a/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiProfile.cs
@@ -81,7 +81,8 @@ namespace WesternStatesWater.WaDE.Accessors.Mapping
                 .ForMember(a => a.VariableSpecifics, b => b.Ignore())
                 .ForMember(a => a.Methods, b => b.Ignore())
                 .ForMember(a => a.BeneficialUses, b => b.Ignore())
-                .ForMember(a => a.AggregatedAmounts, b => b.Ignore());
+                .ForMember(a => a.AggregatedAmounts, b => b.Ignore())
+                .ForMember(a => a.RegulatoryOverlays, b => b.Ignore());
 
             CreateMap<EF.AggregatedAmountsFact, AggregratedAmountsAccessor.AggregatedHelper>()
                 .ForMember(a => a.WaterSourceUUID, b => b.MapFrom(c => c.WaterSource.WaterSourceUuid))
@@ -132,7 +133,8 @@ namespace WesternStatesWater.WaDE.Accessors.Mapping
                 .ForMember(a => a.County, b => b.MapFrom(c => c.Site.County));
 
             CreateMap<EF.ReportingUnitsDim, AccessorApi.ReportingUnit>()
-                .ForMember(a => a.ReportingUnitGeometry, b => b.MapFrom(c => c.Geometry == null ? null : c.Geometry.AsText()));
+                .ForMember(a => a.ReportingUnitGeometry, b => b.MapFrom(c => c.Geometry == null ? null : c.Geometry.AsText()))
+                .ForMember(a => a.RegulatoryOverlayUUIDs, b => b.Ignore());
 
             CreateMap<EF.RegulatoryReportingUnitsFact, RegulatoryOverlayAccessor.ReportingUnitRegulatoryHelper>()
                 .ForMember(a => a.ReportingUnitUUID, b => b.MapFrom(c => c.ReportingUnit.ReportingUnitUuid))

--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/004/013 Core.LoadRegulatoryReportingUnits Name to UUID.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/004/013 Core.LoadRegulatoryReportingUnits Name to UUID.sql
@@ -1,0 +1,109 @@
+﻿CREATE TYPE [Core].[RegulatoryReportingUnitsTableType_new] AS TABLE(
+	[OrganizationUUID] [nvarchar](250) NULL,
+	[RegulatoryOverlayUUID] [nvarchar](250) NULL,
+	[ReportingUnitUUID] [nvarchar](250) NULL,
+	[DataPublicationDate] [nvarchar](250) NULL
+)
+GO
+
+EXEC Core.UpdateUUDT 'Core', 'RegulatoryReportingUnitsTableType';
+GO
+
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+ALTER PROCEDURE [Core].[LoadRegulatoryReportingUnits]
+(
+    @RunId NVARCHAR(250),
+    @RegulatoryReportingUnitsTableType Core.RegulatoryReportingUnitsTableType READONLY
+)
+AS
+BEGIN
+    SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) RowNumber, *
+    INTO #TempRegulatoryReportingUnitData
+    FROM @RegulatoryReportingUnitsTableType;
+	
+	SELECT
+        rrud.*
+        ,dd.DateID 
+		,org.OrganizationID OrgID
+        ,ro.RegulatoryOverlayID RuID
+		,ru.ReportingUnitID ReID
+		
+		
+	INTO
+		 #TempJoinedRegulatoryReportingUnitData
+    FROM
+        #TempRegulatoryReportingUnitData rrud
+		LEFT OUTER JOIN Core.Date_dim dd ON rrud.DataPublicationDate = dd.[Date]
+		LEFT OUTER JOIN Core.Organizations_dim org ON rrud.OrganizationUUID = org.OrganizationUUID
+        LEFT OUTER JOIN Core.RegulatoryOverlay_dim ro ON rrud.RegulatoryOverlayUUID = ro.RegulatoryOverlayUUID
+		LEFT OUTER JOIN Core.ReportingUnits_dim ru ON rrud.ReportingUnitUUID = ru.ReportingUnitUUID;
+       
+    --data validation
+    WITH q1 AS
+    (
+        SELECT 'OrganizationUUID Not Valid' Reason, *
+        FROM  #TempJoinedRegulatoryReportingUnitData
+        WHERE OrganizationUUID IS NULL
+        UNION ALL
+        SELECT 'RegulatoryOverlayUUID Not Valid' Reason, *
+        FROM  #TempJoinedRegulatoryReportingUnitData
+        WHERE RegulatoryOverlayUUID IS NULL
+        UNION ALL
+        SELECT 'ReportingUnitUUID Not Valid' Reason, *
+        FROM  #TempJoinedRegulatoryReportingUnitData
+        WHERE ReportingUnitUUID IS NULL
+        UNION ALL
+        SELECT 'DataPublicationDate Not Valid' Reason, *
+        FROM  #TempJoinedRegulatoryReportingUnitData    
+        WHERE DataPublicationDate IS NULL
+        
+    )
+    SELECT * INTO #TempErrorRegulatoryReportingUnitRecords FROM q1;
+
+    --if we have errors, insert them and bail out
+    IF EXISTS(SELECT 1 FROM #TempErrorRegulatoryReportingUnitRecords) 
+    BEGIN
+        INSERT INTO Core.ImportErrors ([Type], [RunId], [Data])
+        VALUES ('RegulatoryReportingUnits', @RunId, (SELECT * FROM #TempErrorRegulatoryReportingUnitRecords FOR JSON PATH));
+        RETURN 1;
+    END;
+
+	WITH q1 AS
+    (
+        SELECT
+         jrrud.DateID
+		,jrrud.OrgID 
+        ,jrrud.RuID 
+		,jrrud.ReID
+			
+			
+        FROM
+             #TempJoinedRegulatoryReportingUnitData jrrud)
+	
+    --merge the data
+    MERGE INTO Core.RegulatoryReportingUnits_fact AS Target USING q1 AS Source ON
+		Target.OrganizationID = Source.OrgID AND
+		 Target.RegulatoryOverlayID = Source.RuID AND
+          Target.ReportingUnitID = Source.ReID
+    WHEN MATCHED THEN
+		UPDATE SET
+           
+            DataPublicationDateID = Source.DateID
+           
+    WHEN NOT MATCHED THEN
+        INSERT
+            (OrganizationID
+            ,RegulatoryOverlayID
+            ,ReportingUnitID
+            ,DataPublicationDateID)
+        VALUES
+            (Source.OrgID
+            ,Source.RuID
+            ,Source.ReID
+            ,Source.DateID);
+    RETURN 0;
+END

--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/004/013 Core.LoadSiteSpecificAmounts Fix CustomerType.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/004/013 Core.LoadSiteSpecificAmounts Fix CustomerType.sql
@@ -1,0 +1,323 @@
+﻿CREATE TYPE [Core].[SiteSpecificAmountTableType_new] AS TABLE(
+	[OrganizationUUID] [nvarchar](250) NULL,
+	[SiteUUID] [nvarchar](55) NULL,
+	[VariableSpecificUUID] [nvarchar](250) NULL,
+	[WaterSourceUUID] [nvarchar](250) NULL,
+	[MethodUUID] [nvarchar](100) NULL,
+	[TimeframeStart] [date] NULL,
+	[TimeframeEnd] [date] NULL,
+	[DataPublicationDate] [date] NULL,
+	[DataPublicationDOI] [nvarchar](100) NULL,
+	[ReportYearCV] [nvarchar](4) NULL,
+	[Amount] [float] NULL,
+	[PopulationServed] [bigint] NULL,
+	[PowerGeneratedGWh] [float] NULL,
+	[IrrigatedAcreage] [float] NULL,
+	[IrrigationMethodCV] [nvarchar](100) NULL,
+	[CropTypeCV] [nvarchar](100) NULL,
+	[CommunityWaterSupplySystem] [nvarchar](250) NULL,
+	[SDWISIdentifier] [nvarchar](100) NULL,
+	[AssociatedNativeAllocationIDs] [nvarchar](500) NULL,
+	[Geometry] [nvarchar](max) NULL,
+	[BeneficialUseCategory] [nvarchar](500) NULL,
+	[PrimaryUseCategory] [nvarchar](250) NULL,
+	[CustomerTypeCV] [nvarchar](100) NULL,
+	[AllocationCropDutyAmount] [nvarchar](100) NULL,
+	[PowerType] [nvarchar](50) NULL
+)
+GO
+
+EXEC Core.UpdateUUDT 'Core', 'SiteSpecificAmountTableType';
+GO
+
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+ALTER PROCEDURE [Core].[LoadSiteSpecificAmounts]
+(
+    @RunId NVARCHAR(250),
+    @SiteSpecificAmountTable Core.SiteSpecificAmountTableType READONLY
+)
+AS
+BEGIN
+    SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) RowNumber, *
+    INTO #TempSiteSpecificAmountData
+    FROM @SiteSpecificAmountTable;
+    
+    --wire up the foreign keys
+    SELECT
+		ssa.*
+		,og.OrganizationID
+		,st.SiteID
+        ,vb.VariableSpecificID
+        ,wt.WaterSourceID
+		,mt.MethodID
+		,bs.Name
+		,CASE WHEN PopulationServed IS NULL AND CommunityWaterSupplySystem IS NULL 
+						AND CustomerTypeCV IS NULL AND SDWISIdentifier IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN IrrigatedAcreage IS NULL AND CropTypeCV IS NULL 
+						AND IrrigationMethodCV IS NULL AND AllocationCropDutyAmount IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN PowerGeneratedGWh IS NULL AND PowerType IS NULL
+						THEN 0 ELSE 1 END CategoryCount
+	
+	INTO
+		#TempJoinedSiteSpecificAmountData
+    FROM
+        #TempSiteSpecificAmountData ssa
+		LEFT OUTER JOIN Core.Organizations_dim og ON ssa.OrganizationUUID = og.OrganizationUUID
+		LEFT OUTER JOIN Core.Sites_dim st ON ssa.SiteUUID = st.SiteUUID
+		LEFT OUTER JOIN Core.Variables_dim vb ON ssa.VariableSpecificUUID = vb.VariableSpecificUUID
+		LEFT OUTER JOIN Core.WaterSources_dim wt ON ssa.WaterSourceUUID = wt.WaterSourceUUID
+		LEFT OUTER JOIN CVs.BeneficialUses bs ON ssa.PrimaryUseCategory=bs.Name
+		LEFT OUTER JOIN Core.Methods_dim mt ON ssa.MethodUUID = mt.MethodUUID;
+	
+
+    --data validation
+    WITH q1 AS
+    (
+	
+        SELECT 'OrganizationID Not Valid' Reason, *
+        FROM #TempJoinedSiteSpecificAmountData 
+        WHERE OrganizationID IS NULL
+        UNION ALL
+        SELECT 'SiteID Not Valid' Reason, *
+        FROM #TempJoinedSiteSpecificAmountData 
+        WHERE SiteID IS NULL
+        UNION ALL
+        SELECT 'VariableSpecificID Not Valid' Reason, *
+        FROM #TempJoinedSiteSpecificAmountData 
+        WHERE VariableSpecificID IS NULL
+        UNION ALL
+        SELECT 'WaterSourceID Not Valid' Reason, *
+        FROM #TempJoinedSiteSpecificAmountData 
+        WHERE WaterSourceID IS NULL
+        UNION ALL
+        SELECT 'MethodID Not Valid' Reason, *
+        FROM #TempJoinedSiteSpecificAmountData
+        WHERE MethodID IS NULL
+        UNION ALL
+		SELECT 'Amount Not Valid' Reason, *
+        FROM #TempJoinedSiteSpecificAmountData
+        WHERE Amount IS NULL 
+		UNION ALL
+		SELECT 'Cross Group Not Valid' Reason, *
+        FROM #TempJoinedSiteSpecificAmountData
+        WHERE CategoryCount > 1
+		
+    )
+    SELECT * INTO #TempErrorSiteSpecificAmountRecords FROM q1;
+
+    --if we have errors, insert them and bail out
+    IF EXISTS(SELECT 1 FROM #TempErrorSiteSpecificAmountRecords) 
+    BEGIN
+        INSERT INTO Core.ImportErrors ([Type], [RunId], [Data])
+        VALUES ('SiteSpecificAmounts', @RunId, (SELECT * FROM #TempErrorSiteSpecificAmountRecords order by rownumber FOR JSON PATH));
+        RETURN 1;
+    END
+
+    --set up missing Core.BeneficialUses_dim entries
+    SELECT
+        ssa.RowNumber
+        ,BeneficialUse = TRIM(bu.[Value])
+    INTO
+        #TempBeneficialUsesData
+    FROM
+        #TempSiteSpecificAmountData ssa
+        CROSS APPLY STRING_SPLIT(ssa.BeneficialUseCategory, ',') bu
+    WHERE
+        ssa.PrimaryUseCategory IS NOT NULL
+        AND bu.[Value] IS NOT NULL
+        AND LEN(TRIM(bu.[Value])) > 0;
+
+	--INSERT INTO
+ --       CVs.BeneficialUses(Name)
+ --   SELECT DISTINCT
+ --       bud.BeneficialUse
+ --   FROM
+ --       #TempBeneficialUsesData bud
+ --       LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = bud.BeneficialUse
+ --   WHERE
+ --       bu.Name IS NULL;
+
+ --   INSERT INTO
+ --       CVs.BeneficialUses(Name)
+ --   SELECT DISTINCT
+ --       ssa.PrimaryUseCategory
+ --   FROM
+ --       #TempSiteSpecificAmountData ssa
+ --       LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = ssa.PrimaryUseCategory
+ --   WHERE
+ --       bu.Name IS NULL
+ --       AND ssa.PrimaryUseCategory IS NOT NULL
+ --       AND LEN(TRIM(ssa.PrimaryUseCategory)) > 0;
+    
+    --set up missing Core.Date_dim entries
+    WITH q1 AS
+    (
+        SELECT
+            [Date]
+        FROM
+            #TempSiteSpecificAmountData ssa
+            UNPIVOT ([Date] FOR Dates IN (ssa.TimeframeStart, ssa.TimeframeEnd, ssa.DataPublicationDate)) AS up
+	)
+    INSERT INTO Core.Date_dim (Date, Year)
+    SELECT
+        q1.[Date]
+        ,YEAR(q1.[Date])
+    FROM
+        q1
+        LEFT OUTER JOIN Core.Date_dim d ON q1.[Date] = d.[Date]
+    WHERE
+        d.DateID IS NULL AND q1.Date IS NOT NULL
+    GROUP BY
+        q1.[Date];
+    
+    --merge into Core.SiteVariableAmounts_fact
+    CREATE TABLE #SiteVariableAmountRecords(SiteVariableAmountID BIGINT, RowNumber BIGINT);
+    
+    WITH q1 AS
+    (
+        SELECT
+            ssa.OrganizationID
+            ,ssa.SiteID
+           ,ssa.VariableSpecificID
+            ,ssa.WaterSourceID
+            ,ssa.MethodID
+			,TimeframeStart = ds.DateID
+            ,TimeframeEnd = de.DateID
+            ,DataPublicationDate = dp.DateID
+			,ssa.DataPublicationDOI
+            ,ssa.ReportYearCV
+            ,ssa.Amount
+            ,ssa.PopulationServed
+            ,ssa.PowerGeneratedGWh
+            ,ssa.IrrigatedAcreage
+            ,ssa.IrrigationMethodCV
+            ,ssa.CropTypeCV
+			,ssa.CommunityWaterSupplySystem
+			,ssa.SDWISIdentifier
+            ,ssa.AssociatedNativeAllocationIDs
+            ,ssa.[Geometry]
+			,ssa.RowNumber
+			,ssa.CustomerTypeCV
+			,ssa.AllocationCropDutyAmount
+			,ssa.PrimaryUseCategory
+			,ssa.PowerType
+        FROM
+            #TempJoinedSiteSpecificAmountData ssa
+           -- LEFT OUTER JOIN CVs.BeneficialUses bu ON ssa.PrimaryUseCategory = bu.Name
+            LEFT OUTER JOIN Core.Date_dim ds ON ssa.TimeframeStart = ds.[Date]
+            LEFT OUTER JOIN Core.Date_dim de ON ssa.TimeframeEnd = de.[Date]
+            LEFT OUTER JOIN Core.Date_dim dp ON ssa.DataPublicationDate = dp.[Date]
+    )
+    MERGE INTO Core.SiteVariableAmounts_fact AS Target
+	USING q1 AS Source ON
+		ISNULL(Target.OrganizationID, '') = ISNULL(Source.OrganizationID, '')
+		AND ISNULL(Target.SiteID, '') = ISNULL(Source.SiteID, '')
+		AND ISNULL(Target.VariableSpecificID, '') = ISNULL(Source.VariableSpecificID, '')
+		AND ISNULL(Target.TimeframeStartID, '') = ISNULL(Source.TimeframeStart, '')
+		AND ISNULL(Target.TimeframeEndID, '') = ISNULL(Source.TimeframeEnd, '')
+		AND ISNULL(Target.ReportYearCV, '') = ISNULL(Source.ReportYearCV, '')
+		AND ISNULL(Target.PrimaryUseCategoryCV, '') = ISNULL(Source.PrimaryUseCategory, '')
+	WHEN NOT MATCHED THEN
+		INSERT
+			(OrganizationID
+			,SiteID
+			,VariableSpecificID
+			,WaterSourceID
+			,MethodID
+			,TimeframeStartID
+			,TimeframeEndID
+			,DataPublicationDateID
+			,DataPublicationDOI
+			,ReportYearCV
+			,Amount
+			,PopulationServed
+			,PowerGeneratedGWh
+			,IrrigatedAcreage
+			,IrrigationMethodCV
+			,CropTypeCV
+			,CommunityWaterSupplySystem
+			,SDWISIdentifierCV
+			,CustomerTypeCV
+			,AllocationCropDutyAmount
+			,AssociatedNativeAllocationIDs
+			,PrimaryUseCategoryCV
+			,[Geometry]
+			,PowerType)
+		VALUES
+			(Source.OrganizationID
+			,Source.SiteId
+			,Source.VariableSpecificID
+			,Source.WaterSourceID
+			,Source.MethodID
+			,Source.TimeframeStart
+			,Source.TimeframeEnd
+			,Source.DataPublicationDate
+			,Source.DataPublicationDOI
+			,Source.ReportYearCV
+			,Source.Amount
+			,Source.PopulationServed
+			,Source.PowerGeneratedGWh
+			,Source.IrrigatedAcreage
+			,Source.IrrigationMethodCV
+			,Source.CropTypeCV
+			,Source.CommunityWaterSupplySystem
+			,Source.SDWISIdentifier
+			,source.CustomerTypeCV
+			,Source.AllocationCropDutyAmount
+			,Source.AssociatedNativeAllocationIDs
+			,Source.PrimaryUseCategory
+			,geometry::STGeomFromText(Source.[Geometry], 4326)
+			,PowerType)
+        WHEN MATCHED THEN
+	        UPDATE SET
+            OrganizationID = Source.OrganizationID,
+            SiteID = Source.SiteId,
+            VariableSpecificID = Source.VariableSpecificID,
+            WaterSourceID = Source.WaterSourceID,
+            MethodID = Source.MethodID,
+            TimeframeStartID = Source.TimeframeStart,
+			TimeframeEndID = Source.TimeframeEnd,
+            DataPublicationDateID = Source.DataPublicationDate,
+            DataPublicationDOI = Source.DataPublicationDOI,
+            ReportYearCV = Source.ReportYearCV,
+            Amount = Source.Amount,
+            PopulationServed = Source.PopulationServed,
+			PowerGeneratedGWh = Source.PowerGeneratedGWh,
+			IrrigatedAcreage = Source.IrrigatedAcreage,
+			IrrigationMethodCV = Source.IrrigationMethodCV,
+			CropTypeCV = Source.CropTypeCV,
+			CommunityWaterSupplySystem = Source.CommunityWaterSupplySystem,
+			SDWISIdentifierCV = Source.SDWISIdentifier,
+			AssociatedNativeAllocationIDs = Source.AssociatedNativeAllocationIDs,
+			CustomerTypeCV = source.CustomerTypeCV,
+			AllocationCropDutyAmount = Source.AllocationCropDutyAmount,
+			PrimaryUseCategoryCV = Source.PrimaryUseCategory,
+			Geometry = geometry::STGeomFromText(Source.[Geometry], 4326),
+			PowerType = Source.PowerType
+		OUTPUT
+			inserted.SiteVariableAmountID
+			,Source.RowNumber
+		INTO
+			#SiteVariableAmountRecords;
+    
+    --insert into Core.SitesBridge_BeneficialUses_fact
+	INSERT INTO Core.SitesBridge_BeneficialUses_fact (BeneficialUseCV, SiteVariableAmountID)
+	SELECT DISTINCT
+		bu.Name
+		,sva.SiteVariableAmountID
+	FROM
+		#SiteVariableAmountRecords sva
+		LEFT OUTER JOIN #TempBeneficialUsesData bud ON bud.RowNumber = sva.RowNumber
+		LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = bud.BeneficialUse
+	WHERE
+		bu.Name IS NOT NULL AND
+        NOT EXISTS(SELECT 1 from Core.SitesBridge_BeneficialUses_fact innerAB where innerAB.SiteVariableAmountID = sva.SiteVariableAmountID and innerAB.BeneficialUseCV = bu.Name);
+
+	RETURN 0;
+END

--- a/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
+++ b/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
@@ -109,6 +109,8 @@
     <None Remove="Scripts\004\010 Core.Sites_dim Updates.sql" />
     <None Remove="Scripts\004\011 Core.LoadWaterAllocation Null PrimaryUseCategory.sql" />
     <None Remove="Scripts\004\012 Core.LoadAggregatedAmounts Null PrimaryUseCategory.sql" />
+    <None Remove="Scripts\004\013 Core.LoadRegulatoryReportingUnits Name to UUID.sql" />
+    <None Remove="Scripts\004\013 Core.LoadSiteSpecificAmounts Fix CustomerType.sql" />
     <None Remove="Scripts\005 Core.LoadOrganization.sql" />
     <None Remove="Scripts\006 Core.LoadRegulatoryOverlays.sql" />
     <None Remove="Scripts\007 Core.LoadReportingUnits.sql" />
@@ -368,6 +370,8 @@
     <EmbeddedResource Include="Scripts\004\007 Core.AllocationAmounts_fact AllocationPriorityDateID Nullable.sql" />
     <EmbeddedResource Include="Scripts\004\006 Core.AllocationAmounts_fact Update AllocationOwner Size.sql" />
     <EmbeddedResource Include="Scripts\004\005 Core.AllocationAmounts_fact Rename AllocationMaximum.sql" />
+    <EmbeddedResource Include="Scripts\004\013 Core.LoadSiteSpecificAmounts Fix CustomerType.sql" />
+    <EmbeddedResource Include="Scripts\004\013 Core.LoadRegulatoryReportingUnits Name to UUID.sql" />
     <EmbeddedResource Include="Scripts\004\012 Core.LoadAggregatedAmounts Null PrimaryUseCategory.sql" />
     <EmbeddedResource Include="Scripts\004\011 Core.LoadWaterAllocation Null PrimaryUseCategory.sql" />
   </ItemGroup>

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/RegulatoryReportingUnitBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/RegulatoryReportingUnitBuilder.cs
@@ -1,0 +1,34 @@
+﻿using Bogus;
+using WesternStatesWater.WaDE.Accessors.Contracts.Import;
+using WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Import
+{
+    public static class RegulatoryReportingUnitBuilder
+    {
+        public static RegulatoryReportingUnits Create()
+        {
+            return Create(new RegulatoryReportingUnitBuilderOptions());
+        }
+
+        public static RegulatoryReportingUnits Create(RegulatoryReportingUnitBuilderOptions opts)
+        {
+            var faker = new Faker<RegulatoryReportingUnits>()
+                .RuleFor(a => a.OrganizationUUID, f => opts?.Organization?.OrganizationUuid ?? f.Random.Uuid().ToString())
+                .RuleFor(a => a.RegulatoryOverlayUUID, f => opts?.RegulatoryOverlay?.RegulatoryOverlayUuid ?? f.Random.Uuid().ToString())
+                .RuleFor(a => a.ReportingUnitUUID, f => opts?.ReportingUnit?.ReportingUnitUuid ?? f.Random.Uuid().ToString())
+                .RuleFor(a => a.DataPublicationDate, f => opts?.DatePublication?.Date.ToString() ?? f.Date.Past(10).ToString())
+                ;
+
+            return faker;
+        }
+    }
+
+    public class RegulatoryReportingUnitBuilderOptions
+    {
+        public OrganizationsDim Organization { get; set; }
+        public RegulatoryOverlayDim RegulatoryOverlay { get; set; }
+        public ReportingUnitsDim ReportingUnit { get; set; }
+        public DateDim DatePublication { get; set; }
+    }
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/SiteSpecificAmountBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/SiteSpecificAmountBuilder.cs
@@ -21,7 +21,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Import
                 .RuleFor(a => a.WaterSourceUUID, f => opts?.WaterSource?.WaterSourceUuid ?? f.Random.Uuid().ToString())
                 .RuleFor(a => a.DataPublicationDate, f => opts?.DataPublicationDate?.Date ?? f.Date.Past(5))
                 .RuleFor(a => a.ReportYearCV, f => opts?.ReportYear?.Name ?? f.Random.Word())
-                .RuleFor(a => a.IrrigationMethodCV, f => opts?.IrrigationMethod?.Name ?? f.Random.Word())
                 .RuleFor(a => a.BeneficialUseCategory, f => opts?.BeneficialUse?.Name ?? f.Random.Word())
                 .RuleFor(a => a.PrimaryUseCategory, f => opts?.PrimaryUseCategory?.Name ?? f.Random.Word())
                 .RuleFor(a => a.TimeframeStart, f => f.Date.Past(5))
@@ -53,7 +52,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Import
                 case SiteSpecificRecordType.Power:
                     faker
                         .RuleFor(a => a.PowerGeneratedGWh, f => f.Random.Number(1000000).ToString())
-                        .RuleFor(a => a.PowerType, f => f.Random.Word())
+                        .RuleFor(a => a.PowerType, f => opts?.PowerType?.Name ?? f.Random.Word())
                         ;
                     break;
             }
@@ -80,6 +79,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Import
         public BeneficialUsesCV BeneficialUse { get; set; }
         public BeneficialUsesCV PrimaryUseCategory { get; set; }
         public SDWISIdentifier SDWISIdentifier { get; set; }
+        public PowerType PowerType { get; set; }
     }
 
     public enum SiteSpecificRecordType

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/SiteSpecificAmountBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/SiteSpecificAmountBuilder.cs
@@ -1,0 +1,91 @@
+﻿using Bogus;
+using WesternStatesWater.WaDE.Accessors.Contracts.Import;
+using WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Import
+{
+    public static class SiteSpecificAmountBuilder
+    {
+        public static SiteSpecificAmount Create()
+        {
+            return Create(new SiteSpecificAmountBuilderOptions());
+        }
+
+        public static SiteSpecificAmount Create(SiteSpecificAmountBuilderOptions opts)
+        {
+            var faker = new Faker<SiteSpecificAmount>()
+                .RuleFor(a => a.MethodUUID, f => opts?.Method?.MethodUuid ?? f.Random.Uuid().ToString())
+                .RuleFor(a => a.OrganizationUUID, f => opts?.Organization?.OrganizationUuid ?? f.Random.Uuid().ToString())
+                .RuleFor(a => a.SiteUUID, f => opts?.Site?.SiteUuid ?? f.Random.Uuid().ToString())
+                .RuleFor(a => a.VariableSpecificUUID, f => opts?.Variable?.VariableSpecificUuid ?? f.Random.Uuid().ToString())
+                .RuleFor(a => a.WaterSourceUUID, f => opts?.WaterSource?.WaterSourceUuid ?? f.Random.Uuid().ToString())
+                .RuleFor(a => a.DataPublicationDate, f => opts?.DataPublicationDate?.Date ?? f.Date.Past(5))
+                .RuleFor(a => a.ReportYearCV, f => opts?.ReportYear?.Name ?? f.Random.Word())
+                .RuleFor(a => a.IrrigationMethodCV, f => opts?.IrrigationMethod?.Name ?? f.Random.Word())
+                .RuleFor(a => a.BeneficialUseCategory, f => opts?.BeneficialUse?.Name ?? f.Random.Word())
+                .RuleFor(a => a.PrimaryUseCategory, f => opts?.PrimaryUseCategory?.Name ?? f.Random.Word())
+                .RuleFor(a => a.TimeframeStart, f => f.Date.Past(5))
+                .RuleFor(a => a.TimeframeEnd, f => f.Date.Past(5))
+                .RuleFor(a => a.Amount, f => f.Random.Double(0, double.MaxValue).ToString())
+                .RuleFor(a => a.AssociatedNativeAllocationIDs, f => f.Random.Uuid().ToString())
+                ;
+
+            switch (opts?.RecordType ?? (new Faker().PickRandom<SiteSpecificRecordType>()))
+            {
+                case SiteSpecificRecordType.Civilian:
+                    faker
+                        .RuleFor(a => a.PopulationServed, f => f.Random.Number(10000).ToString())
+                        .RuleFor(a => a.CommunityWaterSupplySystem, f => f.Random.Word())
+                        .RuleFor(a => a.CustomerTypeCV, f => opts?.CustomerType?.Name ?? f.Random.Word())
+                        .RuleFor(a => a.SDWISIdentifier, f => opts?.SDWISIdentifier?.Name ?? f.Random.Word())
+                        ;
+                    break;
+
+                case SiteSpecificRecordType.Ag:
+                    faker
+                        .RuleFor(a => a.IrrigatedAcreage, f => f.Random.Double(0, 10000).ToString())
+                        .RuleFor(a => a.CropTypeCV, f => opts?.CropType?.Name ?? f.Random.Word())
+                        .RuleFor(a => a.IrrigationMethodCV, f => opts?.IrrigationMethod?.Name ?? f.Random.Word())
+                        .RuleFor(a => a.AllocationCropDutyAmount, f => f.Random.Double(0, 10000).ToString())
+                        ;
+                    break;
+
+                case SiteSpecificRecordType.Power:
+                    faker
+                        .RuleFor(a => a.PowerGeneratedGWh, f => f.Random.Number(1000000).ToString())
+                        .RuleFor(a => a.PowerType, f => f.Random.Word())
+                        ;
+                    break;
+            }
+
+            return faker;
+        }
+
+
+    }
+
+    public class SiteSpecificAmountBuilderOptions
+    {
+        public SiteSpecificRecordType? RecordType { get; set; }
+        public MethodsDim Method { get; set; }
+        public OrganizationsDim Organization { get; set; }
+        public SitesDim Site { get; set; }
+        public VariablesDim Variable { get; set; }
+        public WaterSourcesDim WaterSource { get; set; }
+        public DateDim DataPublicationDate { get; set; }
+        public ReportYearCv ReportYear { get; set; }
+        public IrrigationMethod IrrigationMethod { get; set; }
+        public CropType CropType { get; set; }
+        public CustomerType CustomerType { get; set; }
+        public BeneficialUsesCV BeneficialUse { get; set; }
+        public BeneficialUsesCV PrimaryUseCategory { get; set; }
+        public SDWISIdentifier SDWISIdentifier { get; set; }
+    }
+
+    public enum SiteSpecificRecordType
+    {
+        Ag,
+        Civilian,
+        Power
+    }
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CustomerTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CustomerTypeBuilder.cs
@@ -4,16 +4,16 @@ using WesternStatesWater.WaDE.Accessors.EntityFramework;
 
 namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
-    public static class CropTypeBuilder
+    public static class CustomerTypeBuilder
     {
-        public static CropType Create()
+        public static CustomerType Create()
         {
-            return Create(new CropTypeBuilderOptions());
+            return Create(new CustomerTypeBuilderOptions());
         }
 
-        public static CropType Create(CropTypeBuilderOptions opts)
+        public static CustomerType Create(CustomerTypeBuilderOptions opts)
         {
-            return new Faker<CropType>()
+            return new Faker<CustomerType>()
                 .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
@@ -21,16 +21,16 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
         }
 
-        public static async Task<CropType> Load(WaDEContext db)
+        public static async Task<CustomerType> Load(WaDEContext db)
         {
-            return await Load(db, new CropTypeBuilderOptions());
+            return await Load(db, new CustomerTypeBuilderOptions());
         }
 
-        public static async Task<CropType> Load(WaDEContext db, CropTypeBuilderOptions opts)
+        public static async Task<CustomerType> Load(WaDEContext db, CustomerTypeBuilderOptions opts)
         {
             var item = Create(opts);
 
-            db.CropType.Add(item);
+            db.CustomerType.Add(item);
             await db.SaveChangesAsync();
 
             return item;
@@ -42,7 +42,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         }
     }
 
-    public class CropTypeBuilderOptions
+    public class CustomerTypeBuilderOptions
     {
 
     }

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/IrrigationMethodBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/IrrigationMethodBuilder.cs
@@ -4,16 +4,16 @@ using WesternStatesWater.WaDE.Accessors.EntityFramework;
 
 namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
-    public static class CropTypeBuilder
+    public static class IrrigationMethodBuilder
     {
-        public static CropType Create()
+        public static IrrigationMethod Create()
         {
-            return Create(new CropTypeBuilderOptions());
+            return Create(new IrrigationMethodBuilderOptions());
         }
 
-        public static CropType Create(CropTypeBuilderOptions opts)
+        public static IrrigationMethod Create(IrrigationMethodBuilderOptions opts)
         {
-            return new Faker<CropType>()
+            return new Faker<IrrigationMethod>()
                 .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
@@ -21,16 +21,16 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
         }
 
-        public static async Task<CropType> Load(WaDEContext db)
+        public static async Task<IrrigationMethod> Load(WaDEContext db)
         {
-            return await Load(db, new CropTypeBuilderOptions());
+            return await Load(db, new IrrigationMethodBuilderOptions());
         }
 
-        public static async Task<CropType> Load(WaDEContext db, CropTypeBuilderOptions opts)
+        public static async Task<IrrigationMethod> Load(WaDEContext db, IrrigationMethodBuilderOptions opts)
         {
             var item = Create(opts);
 
-            db.CropType.Add(item);
+            db.IrrigationMethod.Add(item);
             await db.SaveChangesAsync();
 
             return item;
@@ -42,7 +42,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         }
     }
 
-    public class CropTypeBuilderOptions
+    public class IrrigationMethodBuilderOptions
     {
 
     }

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/PowerTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/PowerTypeBuilder.cs
@@ -4,16 +4,16 @@ using WesternStatesWater.WaDE.Accessors.EntityFramework;
 
 namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
-    public static class CropTypeBuilder
+    public static class PowerTypeBuilder
     {
-        public static CropType Create()
+        public static PowerType Create()
         {
-            return Create(new CropTypeBuilderOptions());
+            return Create(new PowerTypeBuilderOptions());
         }
 
-        public static CropType Create(CropTypeBuilderOptions opts)
+        public static PowerType Create(PowerTypeBuilderOptions opts)
         {
-            return new Faker<CropType>()
+            return new Faker<PowerType>()
                 .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
@@ -21,16 +21,16 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
         }
 
-        public static async Task<CropType> Load(WaDEContext db)
+        public static async Task<PowerType> Load(WaDEContext db)
         {
-            return await Load(db, new CropTypeBuilderOptions());
+            return await Load(db, new PowerTypeBuilderOptions());
         }
 
-        public static async Task<CropType> Load(WaDEContext db, CropTypeBuilderOptions opts)
+        public static async Task<PowerType> Load(WaDEContext db, PowerTypeBuilderOptions opts)
         {
             var item = Create(opts);
 
-            db.CropType.Add(item);
+            db.PowerType.Add(item);
             await db.SaveChangesAsync();
 
             return item;
@@ -42,7 +42,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         }
     }
 
-    public class CropTypeBuilderOptions
+    public class PowerTypeBuilderOptions
     {
 
     }

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayDimBuilder.cs
@@ -1,0 +1,64 @@
+﻿using System.Threading.Tasks;
+using Bogus;
+using WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
+{
+    public static class RegulatoryOverlayDimBuilder
+    {
+        public static RegulatoryOverlayDim Create()
+        {
+            return Create(new RegulatoryOverlayDimBuilderOptions());
+        }
+
+        public static RegulatoryOverlayDim Create(RegulatoryOverlayDimBuilderOptions opts)
+        {
+            return new Faker<RegulatoryOverlayDim>()
+                .RuleFor(a => a.RegulatoryOverlayUuid, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.RegulatoryOverlayNativeId, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.RegulatoryName, f => f.Company.CompanyName())
+                .RuleFor(a => a.RegulatoryDescription, f => f.Rant.ToString())
+                .RuleFor(a => a.RegulatoryStatusCv, f => opts?.RegulatoryStatus?.Name ?? f.Random.Word())
+                .RuleFor(a => a.OversightAgency, f => f.Company.CompanyName())
+                .RuleFor(a => a.RegulatoryStatute, f => f.Random.Word())
+                .RuleFor(a => a.RegulatoryStatuteLink, f => f.Internet.Url())
+                .RuleFor(a => a.StatutoryEffectiveDate, f => f.Date.Past(10))
+                .RuleFor(a => a.StatutoryEndDate, f => f.Date.Past(5))
+                .RuleFor(a => a.RegulatoryOverlayTypeCV, f => opts?.RegulatoryOverlayType?.Name ?? f.Random.AlphaNumeric(10))
+                .RuleFor(a => a.WaterSourceTypeCV, f => opts?.WaterSourceType?.Name ?? f.Random.AlphaNumeric(10));
+        }
+
+        public static async Task<RegulatoryOverlayDim> Load(WaDEContext db)
+        {
+            return await Load(db, new RegulatoryOverlayDimBuilderOptions());
+        }
+
+        public static async Task<RegulatoryOverlayDim> Load(WaDEContext db, RegulatoryOverlayDimBuilderOptions opts)
+        {
+            opts = opts ?? new RegulatoryOverlayDimBuilderOptions();
+
+            opts.RegulatoryStatus = opts.RegulatoryStatus ?? await RegulatoryStatusBuilder.Load(db);
+            opts.RegulatoryOverlayType = opts.RegulatoryOverlayType ?? await RegulatoryOverlayTypeBuilder.Load(db);
+            opts.WaterSourceType = opts.WaterSourceType ?? await WaterSourceTypeBuilder.Load(db);
+
+            var item = Create(opts);
+
+            db.RegulatoryOverlayDim.Add(item);
+            await db.SaveChangesAsync();
+
+            return item;
+        }
+
+        public static long GenerateId()
+        {
+            return new Faker().Random.Long(1);
+        }
+    }
+
+    public class RegulatoryOverlayDimBuilderOptions
+    {
+        public RegulatoryStatus RegulatoryStatus { get; set; }
+        public RegulatoryOverlayType RegulatoryOverlayType { get; set; }
+        public WaterSourceType WaterSourceType { get; set; }
+    }
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayTypeBuilder.cs
@@ -1,0 +1,49 @@
+﻿using System.Threading.Tasks;
+using Bogus;
+using WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
+{
+    public static class RegulatoryOverlayTypeBuilder
+    {
+        public static RegulatoryOverlayType Create()
+        {
+            return Create(new RegulatoryOverlayTypeBuilderOptions());
+        }
+
+        public static RegulatoryOverlayType Create(RegulatoryOverlayTypeBuilderOptions opts)
+        {
+            return new Faker<RegulatoryOverlayType>()
+                .RuleFor(a => a.Name, f => f.Date.Past(5).Year.ToString())
+                .RuleFor(a => a.Term, f => f.Random.Word())
+                .RuleFor(a => a.Definition, f => f.Random.Words(5))
+                .RuleFor(a => a.State, f => f.Address.StateAbbr())
+                .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
+        }
+
+        public static async Task<RegulatoryOverlayType> Load(WaDEContext db)
+        {
+            return await Load(db, new RegulatoryOverlayTypeBuilderOptions());
+        }
+
+        public static async Task<RegulatoryOverlayType> Load(WaDEContext db, RegulatoryOverlayTypeBuilderOptions opts)
+        {
+            var item = Create(opts);
+
+            db.RegulatoryOverlayType.Add(item);
+            await db.SaveChangesAsync();
+
+            return item;
+        }
+
+        public static long GenerateId()
+        {
+            return new Faker().Random.Long(1);
+        }
+    }
+
+    public class RegulatoryOverlayTypeBuilderOptions
+    {
+        
+    }
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryStatusBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryStatusBuilder.cs
@@ -1,0 +1,49 @@
+﻿using System.Threading.Tasks;
+using Bogus;
+using WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
+{
+    public static class RegulatoryStatusBuilder
+    {
+        public static RegulatoryStatus Create()
+        {
+            return Create(new RegulatoryStatusBuilderOptions());
+        }
+
+        public static RegulatoryStatus Create(RegulatoryStatusBuilderOptions opts)
+        {
+            return new Faker<RegulatoryStatus>()
+                .RuleFor(a => a.Name, f => f.Date.Past(5).Year.ToString())
+                .RuleFor(a => a.Term, f => f.Random.Word())
+                .RuleFor(a => a.Definition, f => f.Random.Words(5))
+                .RuleFor(a => a.State, f => f.Address.StateAbbr())
+                .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
+        }
+
+        public static async Task<RegulatoryStatus> Load(WaDEContext db)
+        {
+            return await Load(db, new RegulatoryStatusBuilderOptions());
+        }
+
+        public static async Task<RegulatoryStatus> Load(WaDEContext db, RegulatoryStatusBuilderOptions opts)
+        {
+            var item = Create(opts);
+
+            db.RegulatoryStatus.Add(item);
+            await db.SaveChangesAsync();
+
+            return item;
+        }
+
+        public static long GenerateId()
+        {
+            return new Faker().Random.Long(1);
+        }
+    }
+
+    public class RegulatoryStatusBuilderOptions
+    {
+        
+    }
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportYearCvBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportYearCvBuilder.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using Bogus;
+using WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
+{
+    public static class ReportYearCvBuilder
+    {
+        public static ReportYearCv Create()
+        {
+            return Create(new ReportYearCvBuilderOptions());
+        }
+
+        public static ReportYearCv Create(ReportYearCvBuilderOptions opts)
+        {
+            return new Faker<ReportYearCv>()
+                .RuleFor(a => a.Name, f => f.Date.Past(5).Year.ToString())
+                .RuleFor(a => a.Term, f => f.Random.Word())
+                .RuleFor(a => a.Definition, f => f.Random.Words(5))
+                .RuleFor(a => a.State, f => f.Address.StateAbbr())
+                .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
+        }
+
+        public static async Task<ReportYearCv> Load(WaDEContext db)
+        {
+            return await Load(db, new ReportYearCvBuilderOptions());
+        }
+
+        public static async Task<ReportYearCv> Load(WaDEContext db, ReportYearCvBuilderOptions opts)
+        {
+            var item = Create(opts);
+
+            db.ReportYearCv.Add(item);
+            await db.SaveChangesAsync();
+
+            return item;
+        }
+    }
+
+    public class ReportYearCvBuilderOptions
+    {
+
+    }
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SDWISIdentifierBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SDWISIdentifierBuilder.cs
@@ -1,0 +1,46 @@
+﻿using Bogus;
+using System.Threading.Tasks;
+using WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+public static class SDWISIdentifierBuilder
+{
+    public static SDWISIdentifier Create()
+    {
+        return Create(new SDWISIdentifierBuilderOptions());
+    }
+
+    public static SDWISIdentifier Create(SDWISIdentifierBuilderOptions opts)
+    {
+        return new Faker<SDWISIdentifier>()
+            .RuleFor(a => a.Name, f => f.Date.Past(5).Year.ToString())
+            .RuleFor(a => a.Term, f => f.Random.Word())
+            .RuleFor(a => a.Definition, f => f.Random.Words(5))
+            .RuleFor(a => a.State, f => f.Address.StateAbbr())
+            .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
+    }
+
+    public static async Task<SDWISIdentifier> Load(WaDEContext db)
+    {
+        return await Load(db, new SDWISIdentifierBuilderOptions());
+    }
+
+    public static async Task<SDWISIdentifier> Load(WaDEContext db, SDWISIdentifierBuilderOptions opts)
+    {
+        var item = Create(opts);
+
+        db.SDWISIdentifier.Add(item);
+        await db.SaveChangesAsync();
+
+        return item;
+    }
+
+    public static long GenerateId()
+    {
+        return new Faker().Random.Long(1);
+    }
+}
+
+public class SDWISIdentifierBuilderOptions
+{
+
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SitesDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SitesDimBuilder.cs
@@ -20,7 +20,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             WKTReader shapeMaker = new WKTReader(geometryFactory);                        
 
             var faker = new Faker<SitesDim>()
-                .RuleFor(a => a.SiteUuid, f => f.Random.AlphaNumeric(200))
+                .RuleFor(a => a.SiteUuid, f => f.Random.AlphaNumeric(55))
                 .RuleFor(a => a.SiteNativeId, f => f.Random.AlphaNumeric(50))
                 .RuleFor(a => a.SiteName, f => f.Random.AlphaNumeric(500))
                 .RuleFor(a => a.UsgssiteId, f => f.Random.AlphaNumeric(250))


### PR DESCRIPTION
* Updated RegulatoryReportingUnit header names
  * OrganizationName > OrganizationUUID
  * RegulatoryOverlayName > RegulatoryOverlayUUID
  * ReportingUnitName > ReportingUnitUUID
  * DataPublicationDateID > DataPublicationDate
* Added PowerType to DbContext so tests could inject data
  * Additionally noticed PowerType was missing from EF contracts
* #91 Fixed Site Specific Amounts merge column mismatch.