### PR TITLE
Added default connection string to local.settings.json

### DIFF
--- a/source/WaDEImportFunctions/local.settings.json
+++ b/source/WaDEImportFunctions/local.settings.json
@@ -5,6 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet"
   },
   "ConnectionStrings": {
-    "AzureStorage": "UseDevelopmentStorage=true"
+    "AzureStorage": "UseDevelopmentStorage=true",
+    "WadeDatabase": "Server=.;Initial Catalog=WaDE2;Integrated Security=true;"
   }
 }


### PR DESCRIPTION
Currently no connection string exists when running importer unless the user creates their own `settings.{computername}.json` or sets an environment variable.