### PR TITLE
Changes to AllocationUUID and PrimaryBeneficialUseCategory

### DIFF
--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/Allocation.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/Allocation.cs
@@ -22,6 +22,7 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Api
         public double? AllocationCropDutyAmount { get; set; }
         public double? AllocationFlow_CFS { get; set; }
         public double? AllocationVolume_AF { get; set; }
+        public string AllocationUUID { get; set; }
         public long? PopulationServed { get; set; }
         public double? GeneratedPowerCapacityMW { get; set; }
         public string AllocationCommunityWaterSupplySystem { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Import/WaterAllocation.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Import/WaterAllocation.cs
@@ -22,7 +22,7 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Import
         public string BeneficialUseCategory { get; set; }
         
         [NullValues("")]
-        public string PrimaryUseCategory { get; set; }
+        public string PrimaryBeneficialUseCategory { get; set; }
 
         public DateTime? DataPublicationDate { get; set; }
 
@@ -69,6 +69,9 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Import
 
         [NullValues("")]
         public string AllocationVolume_AF { get; set; }
+
+        [NullValues("")]
+        public string AllocationUUID { get; set; }
 
         [NullValues("")]
         public string PopulationServed { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AllocationAmountsFact.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AllocationAmountsFact.cs
@@ -50,6 +50,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public bool? ExemptOfVolumeFlowPriority { get; set; }
         public string PowerType { get; set; }
         public string OwnerClassificationCV { get; set; }
+        public string AllocationUUID { get; set; }
 
         public virtual DateDim AllocationApplicationDateNavigation { get; set; }
         public virtual WaterAllocationBasis AllocationBasisCvNavigation { get; set; }
@@ -60,7 +61,6 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public virtual DateDim DataPublicationDate { get; set; }
         public virtual MethodsDim Method { get; set; }
         public virtual OrganizationsDim Organization { get; set; }
-        public virtual BeneficialUsesCV PrimaryBeneficialUse { get; set; }
         public virtual VariablesDim VariableSpecific { get; set; }
         public virtual CropType CropType { get; set; }
         public virtual CustomerType CustomerType { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/BeneficialUsesCV.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/BeneficialUsesCV.cs
@@ -9,7 +9,6 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         {
             AggBridgeBeneficialUsesFact = new HashSet<AggBridgeBeneficialUsesFact>();
             AggregatedAmountsFact = new HashSet<AggregatedAmountsFact>();
-            AllocationAmountsFact = new HashSet<AllocationAmountsFact>();
             AllocationBridgeBeneficialUsesFact = new HashSet<AllocationBridgeBeneficialUsesFact>();
             SitesBridgeBeneficialUsesFact = new HashSet<SitesBridgeBeneficialUsesFact>();
             SiteVariableAmountsFact = new HashSet<SiteVariableAmountsFact>();
@@ -30,7 +29,6 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         
         public virtual ICollection<AggBridgeBeneficialUsesFact> AggBridgeBeneficialUsesFact { get; set; }
         public virtual ICollection<AggregatedAmountsFact> AggregatedAmountsFact { get; set; }
-        public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }
         public virtual ICollection<AllocationBridgeBeneficialUsesFact> AllocationBridgeBeneficialUsesFact { get; set; }
         public virtual ICollection<SitesBridgeBeneficialUsesFact> SitesBridgeBeneficialUsesFact { get; set; }
         public virtual ICollection<SiteVariableAmountsFact> SiteVariableAmountsFact { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
@@ -408,7 +408,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
                 entity.Property(e => e.GeneratedPowerCapacityMW).HasColumnName("GeneratedPowerCapacityMW");
 
-                entity.Property(e => e.PrimaryUseCategoryCV).HasColumnName("PrimaryUseCategoryCV");
+                entity.Property(e => e.PrimaryUseCategoryCV).HasColumnName("PrimaryBeneficialUseCategory");
 
                 entity.Property(e => e.VariableSpecificId).HasColumnName("VariableSpecificID");
 
@@ -464,11 +464,6 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                     .HasForeignKey(d => d.OrganizationId)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("fk_AllocationAmounts_fact_Organizations_dim");
-
-                entity.HasOne(d => d.PrimaryBeneficialUse)
-                    .WithMany(p => p.AllocationAmountsFact)
-                    .HasForeignKey(d => d.PrimaryUseCategoryCV)
-                    .HasConstraintName("fk_AllocationAmounts_fact_BeneficialUses");
 
                 entity.HasOne(d => d.VariableSpecific)
                     .WithMany(p => p.AllocationAmountsFact)

--- a/source/WesternStatesWater.WaDE.Accessors/WaterAllocationAccessor.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/WaterAllocationAccessor.cs
@@ -100,7 +100,7 @@ namespace WesternStatesWater.WaDE.Accessors
             }
             if (!string.IsNullOrWhiteSpace(filters.UsgsCategoryNameCv))
             {
-                query = query.Where(a => a.PrimaryBeneficialUse.UsgscategoryNameCv == filters.UsgsCategoryNameCv || a.AllocationBridgeBeneficialUsesFact.Any(b => b.BeneficialUse.UsgscategoryNameCv == filters.UsgsCategoryNameCv));
+                query = query.Where(a => a.AllocationBridgeBeneficialUsesFact.Any(b => b.BeneficialUse.UsgscategoryNameCv == filters.UsgsCategoryNameCv));
             }
             if (filters.Geometry != null)
             {
@@ -311,7 +311,7 @@ namespace WesternStatesWater.WaDE.Accessors
             }
             if (!string.IsNullOrWhiteSpace(filters.UsgsCategoryNameCv))
             {
-                query = query.Where(a => a.PrimaryBeneficialUse.UsgscategoryNameCv == filters.UsgsCategoryNameCv || a.AllocationBridgeBeneficialUsesFact.Any(b => b.BeneficialUse.UsgscategoryNameCv == filters.UsgsCategoryNameCv));
+                query = query.Where(a => a.AllocationBridgeBeneficialUsesFact.Any(b => b.BeneficialUse.UsgscategoryNameCv == filters.UsgsCategoryNameCv));
             }
             if (filters.Geometry != null)
             {
@@ -441,6 +441,7 @@ namespace WesternStatesWater.WaDE.Accessors
             public double? AllocationCropDutyAmount { get; set; }
             public double? AllocationFlow_CFS { get; set; }
             public double? AllocationVolume_AF { get; set; }
+            public string AllocationUUID { get; set; }
             public long? PopulationServed { get; set; }
             public double? GeneratedPowerCapacityMW { get; set; }
             public string AllocationCommunityWaterSupplySystem { get; set; }

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Allocation.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Allocation.cs
@@ -22,6 +22,7 @@ namespace WesternStatesWater.WaDE.Contracts.Api
         public double? AllocationFlow_CFS { get; set; }
         public double? AllocationVolume_AF { get; set; }
         public long? PopulationServed { get; set; }
+        public string AllocationUUID { get; set; }
         public double? GeneratedPowerCapacityMW { get; set; }
         public string AllocationCommunityWaterSupplySystem { get; set; }
         public string AllocationSDWISIdentifier { get; set; }

--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/005/004 AddAllocationUUIDChangePrimaryUseCategoryOnAllocationAmountsFact.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/005/004 AddAllocationUUIDChangePrimaryUseCategoryOnAllocationAmountsFact.sql
@@ -1,0 +1,442 @@
+USE [WaDE2]
+GO
+
+DELETE FROM [Core].[AllocationBridge_BeneficialUses_fact];
+DELETE FROM [Core].[AllocationBridge_Sites_fact];
+DELETE FROM [Core].[AllocationAmounts_fact];
+ALTER TABLE [Core].[AllocationAmounts_fact] Add AllocationUUID NVARCHAR (250) NOT NULL;
+GO
+
+EXEC sp_rename '[Core].[AllocationAmounts_fact].PrimaryUseCategoryCV', 'PrimaryBeneficialUseCategory', 'COLUMN';
+ALTER TABLE [Core].[AllocationAmounts_fact] DROP CONSTRAINT FK_AllocationAmounts_BeneficialUses;
+ALTER TABLE Core.AllocationAmounts_fact
+ALTER COLUMN PrimaryBeneficialUseCategory NVARCHAR(150) NULL;
+CREATE UNIQUE INDEX IX_AllocationUUID on [Core].[AllocationAmounts_fact] (AllocationUUID);
+GO
+
+/****** Object:  UserDefinedTableType [Core].[WaterAllocationTableType]    Script Date: 6/13/2022 3:14:49 PM ******/
+CREATE TYPE [Core].[WaterAllocationTableType_new] AS TABLE(
+	[OrganizationUUID] [nvarchar](250) NULL,
+	[VariableSpecificUUID] [nvarchar](250) NULL,
+	[SiteUUID] [nvarchar](max) NULL,
+	[MethodUUID] [nvarchar](250) NULL,
+	[BeneficialUseCategory] [nvarchar](500) NULL,
+	[PrimaryBeneficialUseCategory] [nvarchar](150) NULL,
+	[DataPublicationDATE] [date] NULL,
+	[DataPublicationDOI] [nvarchar](100) NULL,
+	[AllocationNativeID] [nvarchar](250) NULL,
+	[AllocationApplicationDate] [date] NULL,
+	[AllocationPriorityDate] [date] NULL,
+	[AllocationExpirationDate] [date] NULL,
+	[AllocationOwner] [nvarchar](500) NULL,
+	[AllocationBasisCV] [nvarchar](250) NULL,
+	[AllocationLegalStatusCV] [varchar](250) NULL,
+	[AllocationTypeCV] [nvarchar](250) NULL,
+	[AllocationTimeframeStart] [nvarchar](6) NULL,
+	[AllocationTimeframeEnd] [nvarchar](6) NULL,
+	[AllocationCropDutyAmount] [float] NULL,
+	[AllocationFlow_CFS] [float] NULL,
+	[AllocationVolume_AF] [float] NULL,
+	[AllocationUUID] [nvarchar](250) NULL,
+	[PopulationServed] [bigint] NULL,
+	[GeneratedPowerCapacityMW] [float] NULL,
+	[IrrigatedAcreage] [float] NULL,
+	[AllocationCommunityWaterSupplySystem] [nvarchar](250) NULL,
+	[AllocationSDWISIdentifier] [nvarchar](250) NULL,
+	[AllocationAssociatedWithdrawalSiteIDs] [nvarchar](500) NULL,
+	[AllocationAssociatedConsumptiveUseSiteIDs] [nvarchar](500) NULL,
+	[AllocationChangeApplicationIndicator] [nvarchar](250) NULL,
+	[LegacyAllocationIDs] [nvarchar](250) NULL,
+	[CustomerType] [nvarchar](100) NULL,
+	[IrrigationMethodCV] [nvarchar](100) NULL,
+	[CropTypeCV] [nvarchar](100) NULL,
+	[WaterAllocationNativeURL] [nvarchar](250) NULL,
+	[CommunityWaterSupplySystem] [nvarchar](250) NULL,
+	[PowerType] [nvarchar](50) NULL,
+	[ExemptOfVolumeFlowPriority] [bit] NULL,
+	[OwnerClassificationCV] [nvarchar](250) NULL
+)
+GO
+
+EXEC Core.UpdateUUDT 'Core', 'WaterAllocationTableType';
+GO
+
+
+USE [WaDE2]
+GO
+
+
+
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+ALTER   PROCEDURE [Core].[LoadWaterAllocation]
+(
+	@RunId nvarchar(250),
+	@WaterAllocationTable Core.WaterAllocationTableType READONLY
+)
+AS
+BEGIN
+	SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) RowNumber, *
+	INTO #TempWaterAllocationData
+	FROM @WaterAllocationTable;
+
+	--wire up the foreign keys
+	SELECT
+		wad.*
+		,o.OrganizationID
+		,v.VariableSpecificID
+		,m.MethodID
+		,oc.[Name] OwnerClassificationFK
+		,CASE WHEN PopulationServed IS NULL AND CommunityWaterSupplySystem IS NULL 
+						AND CustomerType IS NULL AND AllocationSDWISIdentifier IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN IrrigatedAcreage IS NULL AND CropTypeCV IS NULL 
+						AND IrrigationMethodCV IS NULL AND AllocationCropDutyAmount IS NULL
+						THEN 0 ELSE 1 END
+					+ CASE WHEN GeneratedPowerCapacityMW IS NULL AND PowerType IS NULL
+						THEN 0 ELSE 1 END CategoryCount
+	INTO
+		#TempJoinedWaterAllocationData
+	FROM
+		#TempWaterAllocationData wad
+		LEFT OUTER JOIN Core.Organizations_dim o ON o.OrganizationUUID = wad.OrganizationUUID
+		LEFT OUTER JOIN Core.Variables_dim v ON v.VariableSpecificUUID = wad.VariableSpecificUUID
+		LEFT OUTER JOIN Core.Methods_dim m ON m.MethodUUID = wad.MethodUUID
+		LEFT OUTER JOIN CVs.OwnerClassification oc ON oc.[Name] = wad.OwnerClassificationCV;
+
+	--set up missing Core.BeneficialUses_dim entries
+	SELECT
+		wad.RowNumber
+		,BeneficialUse = buTable.Name
+	INTO
+		#TempBeneficialUsesData
+	FROM
+		#TempWaterAllocationData wad CROSS APPLY
+		STRING_SPLIT(wad.BeneficialUseCategory, ',') bu left outer join
+		CVs.BeneficialUses buTable ON buTable.Name=TRIM(bu.[Value])
+	WHERE
+		bu.[Value] IS NOT NULL
+		AND LEN(TRIM(bu.[Value])) > 0;
+
+	--data validation
+	WITH q1 AS
+	(
+		SELECT 'AllocationUUID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE AllocationUUID IS NULL
+		UNION ALL
+		SELECT 'OrganizationID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE OrganizationID IS NULL
+		UNION ALL
+		SELECT 'VariableSpecificID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE VariableSpecificID IS NULL
+		UNION ALL
+		SELECT 'MethodID Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE MethodID IS NULL
+		UNION ALL
+		SELECT 'OwnerClassificationCV Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE OwnerClassificationCV IS NOT NULL AND OwnerClassificationFK IS NULL
+		UNION ALL
+		SELECT 'DataPublicationDate Not Valid' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE DataPublicationDate IS NULL
+		UNION ALL
+		SELECT 'Cross Group Not Valid' Reason, *
+        FROM #TempJoinedWaterAllocationData
+        WHERE CategoryCount >1
+		UNION ALL
+		SELECT 'Allocation Not Exempt of Volume Flow Priority' Reason, *
+		FROM #TempJoinedWaterAllocationData
+		WHERE (ExemptOfVolumeFlowPriority IS NULL OR ExemptOfVolumeFlowPriority = 0) AND 
+			  (AllocationPriorityDate IS NULL OR (AllocationFlow_CFS IS NULL AND AllocationVolume_AF IS NULL))
+		UNION ALL
+		SELECT 'BeneficialUseCategory Not Valid' Reason, tjwad.*
+		FROM #TempBeneficialUsesData tbud inner join
+		     #TempJoinedWaterAllocationData tjwad on tjwad.RowNumber = tbud.RowNumber
+		WHERE tbud.BeneficialUse IS NULL
+	)
+	SELECT * INTO #TempErrorWaterAllocationRecords FROM q1;
+
+	--if we have errors, insert them and bail out
+	IF EXISTS(SELECT 1 FROM #TempErrorWaterAllocationRecords) 
+	BEGIN
+		INSERT INTO Core.ImportErrors ([Type], [RunId], [Data])
+		VALUES ('WaterAllocations', @RunId, (SELECT * FROM #TempErrorWaterAllocationRecords FOR JSON PATH));
+		RETURN 1;
+	END
+
+	--set up missing Core.Sites_dim entries
+	SELECT
+		wad.RowNumber
+		,SiteUUID = TRIM(s.[Value]) 
+	INTO
+		#TempSitesData
+	FROM
+		#TempWaterAllocationData wad
+		CROSS APPLY STRING_SPLIT(wad.SiteUUID, ',') s
+	WHERE
+		s.[Value] IS NOT NULL
+		AND LEN(TRIM(s.[Value])) > 0;
+
+	--set up missing Core.Date_dim entries
+	WITH q1 AS
+	(
+		SELECT [Date]
+		FROM #TempWaterAllocationData wad
+		UNPIVOT ([Date] FOR Dates IN (wad.DataPublicationDATE, wad.AllocationApplicationDate, wad.AllocationPriorityDate, wad.AllocationExpirationDate)) AS up
+	)
+	INSERT INTO Core.Date_dim (Date, Year)
+	SELECT
+		q1.[Date]
+		,YEAR(q1.[Date])
+	FROM
+		q1
+		LEFT OUTER JOIN Core.Date_dim d ON q1.[Date] = d.[Date]
+	WHERE
+        d.DateID IS NULL AND q1.[Date] IS NOT NULL
+    GROUP BY
+        q1.[Date];
+
+	--merge into Core.AllocationAmounts_fact
+	CREATE TABLE #AllocationAmountRecords(AllocationAmountID BIGINT, RowNumber BIGINT);
+
+	WITH q1 AS
+	(
+		SELECT
+			wad.OrganizationID
+			,wad.VariableSpecificID
+			,wad.MethodID
+			,wad.PrimaryBeneficialUseCategory
+			,DataPublicationDateID = dpub.DateID
+			,wad.DataPublicationDOI
+			,wad.AllocationNativeID
+			,AllocationApplicationDate = dApp.DateID
+			,AllocationPriorityDate = dPri.DateID
+			,AllocationExpirationDate = dExp.DateID
+			,wad.AllocationOwner
+			,wad.AllocationBasisCV
+			,wad.AllocationLegalStatusCV
+			,wad.AllocationTypeCV
+			,wad.AllocationTimeframeStart
+			,wad.AllocationTimeframeEnd
+			,wad.AllocationCropDutyAmount
+			,wad.AllocationFlow_CFS
+			,wad.AllocationVolume_AF
+			,wad.PopulationServed
+			,wad.GeneratedPowerCapacityMW
+			,wad.IrrigatedAcreage
+			,wad.AllocationCommunityWaterSupplySystem
+			,wad.AllocationSDWISIdentifier
+			,wad.AllocationAssociatedWithdrawalSiteIDs
+			,wad.AllocationAssociatedConsumptiveUseSiteIDs
+			,wad.AllocationChangeApplicationIndicator
+			,wad.LegacyAllocationIDs
+			,wad.RowNumber
+			,wad.CropTypeCV
+			,wad.CustomerType
+			,wad.IrrigationMethodCV
+			,wad.CommunityWaterSupplySystem
+			,wad.PowerType
+			,wad.ExemptOfVolumeFlowPriority
+			,wad.OwnerClassificationCV
+			,wad.AllocationUUID
+		FROM
+			#TempJoinedWaterAllocationData wad
+			--LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = wad.PrimaryUseCategory
+			LEFT OUTER JOIN Core.Date_dim dPub ON dPub.[Date] = wad.DataPublicationDate
+			LEFT OUTER JOIN Core.Date_dim dApp ON dApp.[Date] = wad.AllocationApplicationDate
+			LEFT OUTER JOIN Core.Date_dim dPri ON dPri.[Date] = wad.AllocationPriorityDate
+			LEFT OUTER JOIN Core.Date_dim dExp ON dExp.[Date] = wad.AllocationExpirationDate
+	)
+	MERGE INTO Core.AllocationAmounts_fact AS Target
+	USING q1 AS Source ON
+		ISNULL(Target.AllocationUUID, '') = ISNULL(Source.AllocationUUID, '')
+	WHEN NOT MATCHED THEN
+	INSERT
+		(OrganizationID
+		,VariableSpecificID
+		,MethodID
+		,PrimaryBeneficialUseCategory
+		,DataPublicationDateID
+		,DataPublicationDOI
+		,AllocationNativeID
+		,AllocationApplicationDateID
+		,AllocationPriorityDateID
+		,AllocationExpirationDateID
+		,AllocationOwner
+		,AllocationBasisCV
+		,AllocationLegalStatusCV
+		,AllocationTypeCV
+		,AllocationTimeframeStart
+		,AllocationTimeframeEnd
+		,AllocationCropDutyAmount
+		,AllocationFlow_CFS
+		,AllocationVolume_AF
+		,PopulationServed
+		,GeneratedPowerCapacityMW
+		,IrrigatedAcreage
+		,AllocationCommunityWaterSupplySystem
+		,SDWISIdentifierCV
+		,AllocationAssociatedWithdrawalSiteIDs
+		,AllocationAssociatedConsumptiveUseSiteIDs
+		,AllocationChangeApplicationIndicator
+		,LegacyAllocationIDs
+		,CropTypeCV
+		,CustomerTypeCV
+		,IrrigationMethodCV
+		,CommunityWaterSupplySystem
+		,PowerType
+		,ExemptOfVolumeFlowPriority
+		,OwnerClassificationCV
+		,AllocationUUID)
+	VALUES
+		(Source.OrganizationID
+		,Source.VariableSpecificID
+		,Source.MethodID
+		,Source.PrimaryBeneficialUseCategory
+		,Source.DataPublicationDateID
+		,Source.DataPublicationDOI
+		,Source.AllocationNativeID
+		,Source.AllocationApplicationDate
+		,Source.AllocationPriorityDate
+		,Source.AllocationExpirationDate
+		,Source.AllocationOwner
+		,Source.AllocationBasisCV
+		,Source.AllocationLegalStatusCV
+		,Source.AllocationTypeCV
+		,Source.AllocationTimeframeStart
+		,Source.AllocationTimeframeEnd
+		,Source.AllocationCropDutyAmount
+		,Source.AllocationFlow_CFS
+		,Source.AllocationVolume_AF
+		,Source.PopulationServed
+		,Source.GeneratedPowerCapacityMW
+		,Source.IrrigatedAcreage
+		,Source.AllocationCommunityWaterSupplySystem
+		,Source.AllocationSDWISIdentifier
+		,Source.AllocationAssociatedWithdrawalSiteIDs
+		,Source.AllocationAssociatedConsumptiveUseSiteIDs
+		,Source.AllocationChangeApplicationIndicator
+		,Source.LegacyAllocationIDs
+		,Source.CropTypeCV
+		,Source.CustomerType
+		,Source.IrrigationMethodCV
+		,Source.CommunityWaterSupplySystem
+		,Source.PowerType
+		,Source.ExemptOfVolumeFlowPriority
+		,Source.OwnerClassificationCV
+		,Source.AllocationUUID)
+	WHEN MATCHED THEN
+	  UPDATE SET
+		OrganizationID = Source.OrganizationID,
+		VariableSpecificID = Source.VariableSpecificID,
+		MethodID = Source.MethodID,
+		PrimaryBeneficialUseCategory = Source.PrimaryBeneficialUseCategory,
+		DataPublicationDateID = Source.DataPublicationDateID,
+		DataPublicationDOI = Source.DataPublicationDOI,
+		AllocationNativeID = Source.AllocationNativeID,
+		AllocationApplicationDateID = Source.AllocationApplicationDate,
+		AllocationPriorityDateID = Source.AllocationPriorityDate,
+		AllocationExpirationDateID = Source.AllocationExpirationDate,
+		AllocationOwner = Source.AllocationOwner,
+		AllocationBasisCV = Source.AllocationBasisCV,
+		AllocationLegalStatusCV = Source.AllocationLegalStatusCV,
+		AllocationTypeCV = Source.AllocationTypeCV,
+		AllocationTimeframeStart = Source.AllocationTimeframeStart,
+		AllocationTimeframeEnd = Source.AllocationTimeframeEnd,
+		AllocationCropDutyAmount = Source.AllocationCropDutyAmount,
+		AllocationFlow_CFS = Source.AllocationFlow_CFS,
+		AllocationVolume_AF = Source.AllocationVolume_AF,
+		PopulationServed = Source.PopulationServed,
+		GeneratedPowerCapacityMW = Source.GeneratedPowerCapacityMW,
+		IrrigatedAcreage = Source.IrrigatedAcreage,
+		AllocationCommunityWaterSupplySystem = Source.AllocationCommunityWaterSupplySystem,
+		SDWISIdentifierCV = Source.AllocationSDWISIdentifier,
+		AllocationAssociatedWithdrawalSiteIDs = Source.AllocationAssociatedWithdrawalSiteIDs,
+		AllocationAssociatedConsumptiveUseSiteIDs = Source.AllocationAssociatedConsumptiveUseSiteIDs,
+		AllocationChangeApplicationIndicator = Source.AllocationChangeApplicationIndicator,
+		LegacyAllocationIDs = Source.LegacyAllocationIDs,
+		CropTypeCV = Source.CropTypeCV,
+		CustomerTypeCV = Source.CustomerType,
+		IrrigationMethodCV = Source.IrrigationMethodCV,
+		CommunityWaterSupplySystem = Source.CommunityWaterSupplySystem,
+		PowerType = Source.PowerType,
+		ExemptOfVolumeFlowPriority = Source.ExemptOfVolumeFlowPriority,
+		OwnerClassificationCV = Source.OwnerClassificationCV,
+		AllocationUUID = Source.AllocationUUID
+	OUTPUT
+		inserted.AllocationAmountID
+		,Source.RowNumber
+	INTO
+		#AllocationAmountRecords;
+
+	--merge updates into Core.AllocationBridge_BeneficialUses_fact
+	with q1 as (
+		select *
+		  from Core.AllocationBridge_BeneficialUses_fact abbuf
+		  where abbuf.AllocationAmountID in (select AllocationAmountID from #AllocationAmountRecords)
+	),
+	q2 as (
+		SELECT DISTINCT
+			bu.Name
+			,aar.AllocationAmountID
+		FROM
+			#AllocationAmountRecords aar
+			LEFT OUTER JOIN #TempBeneficialUsesData bud ON bud.RowNumber = aar.RowNumber
+			LEFT OUTER JOIN CVs.BeneficialUses bu ON bu.Name = bud.BeneficialUse
+		WHERE
+			bu.Name IS NOT NULL
+	)
+	MERGE INTO q1 AS Target
+	USING q2 AS Source ON
+		target.AllocationAmountID = source.AllocationAmountID and
+		target.BeneficialUseCv = source.Name
+	WHEN NOT MATCHED THEN
+		INSERT
+			(AllocationAmountID, BeneficialUseCv)
+		VALUES
+			(Source.AllocationAmountID, Source.Name)
+	WHEN Not matched by source THEN
+	  DELETE;
+
+	--merge updates into Core.AllocationBridge_Sites_fact
+	with q1 as (
+		select *
+		  from Core.AllocationBridge_Sites_fact absf
+		  where absf.AllocationAmountID in (select AllocationAmountID from #AllocationAmountRecords)
+	),
+	q2 as (
+		SELECT DISTINCT
+			s.SiteID
+			,aar.AllocationAmountID
+		FROM
+			#AllocationAmountRecords aar
+			LEFT OUTER JOIN #TempSitesData siteData ON siteData.RowNumber = aar.RowNumber
+			LEFT OUTER JOIN Sites_dim s ON s.SiteUUID = siteData.SiteUUID
+		WHERE
+			s.SiteID IS NOT NULL
+	)
+	MERGE INTO q1 AS Target
+	USING q2 AS Source ON
+		target.AllocationAmountID = source.AllocationAmountID and
+		target.SiteID = source.SiteID
+	WHEN NOT MATCHED THEN
+		INSERT
+			(AllocationAmountID, SiteID)
+		VALUES
+			(Source.AllocationAmountID, Source.SiteID)
+	WHEN Not matched by source THEN
+	  DELETE;
+
+	RETURN 0;
+
+END
+GO

--- a/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
+++ b/source/WesternStatesWater.WaDE.DbUp/WesternStatesWater.WaDE.DbUp.csproj
@@ -124,7 +124,8 @@
     <None Remove="Scripts\005 Core.LoadOrganization.sql" />
     <None Remove="Scripts\005\001 SitesAndWaterSourcesManyToMany.sql" />
     <None Remove="Scripts\005\002 ImportMultipleWaterSourcesPerSite.sql" />
-    <None Remove="Scripts\005\003 AddConsumptiveNonconsumptiveFlagBeneficialUses.sql" />
+    <None Remove="Scripts\005\003 AddConsumptiveNonconsumptiveFlagBeneficialUses - Copy.sql" />
+    <None Remove="Scripts\005\004 AddAllocationUUIDChangePrimaryUseCategoryOnAllocationAmountsFact.sql" />
     <None Remove="Scripts\006 Core.LoadRegulatoryOverlays.sql" />
     <None Remove="Scripts\007 Core.LoadReportingUnits.sql" />
     <None Remove="Scripts\008 Core.LoadSites.sql" />
@@ -401,7 +402,8 @@
     <EmbeddedResource Include="Scripts\004\026 LoadSites_AddWaterSourceID.sql" />
     <EmbeddedResource Include="Scripts\005\002 ImportMultipleWaterSourcesPerSite.sql" />
     <EmbeddedResource Include="Scripts\005\001 SitesAndWaterSourcesManyToMany.sql" />
-    <EmbeddedResource Include="Scripts\005\003 AddConsumptiveNonconsumptiveFlagBeneficialUses.sql" />
+    <EmbeddedResource Include="Scripts\005\003 AddConsumptiveNonconsumptiveFlagBeneficialUses - Copy.sql" />
+    <EmbeddedResource Include="Scripts\005\004 AddAllocationUUIDChangePrimaryUseCategoryOnAllocationAmountsFact.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/WaterAllocationBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/WaterAllocationBuilder.cs
@@ -30,6 +30,8 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Import
                 .RuleFor(a => a.AllocationFlow_CFS, f => f.Random.Double(0, 10000).ToString())
                 .RuleFor(a => a.AllocationVolume_AF, f => f.Random.Double(0, 10000).ToString())
                 .RuleFor(a => a.AllocationCommunityWaterSupplySystem, f => f.Address.City())
+                .RuleFor(a => a.AllocationUUID, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.PrimaryBeneficialUseCategory, f => f.Random.Uuid().ToString())
                 ;
 
             switch (opts.RecordType ?? (new Faker()).PickRandom<WaterAllocationRecordType>())

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/AllocationAmountsFactBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/AllocationAmountsFactBuilder.cs
@@ -33,6 +33,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.AllocationTimeframeEnd, f => opts.AllocationTimeframeEndDate?.Date.ToString("mm/dd"))
                 .RuleFor(a => a.AllocationFlow_CFS, f => f.Random.Double(0, 1000))
                 .RuleFor(a => a.AllocationVolume_AF, f => f.Random.Double(0, 1000))
+                .RuleFor(a => a.AllocationUUID, f => f.Random.Guid().ToString())
                 ;
 
             switch (opts.RecordType ?? (new Faker()).PickRandom<WaterAllocationRecordType>())


### PR DESCRIPTION
AllocationAmountsFact now has unique identifier AllocationUUID

PrimaryUseCategory has been renamed PrimaryBeneficialUseCategory and has been updated to allow any string value instead of being pulled from the BeneficialUsesCV table