### PR TITLE
Moving 'site allocation amounts' searches into the handler pattern

### DIFF
--- a/source/WaDEApiFunctions/FunctionBase.cs
+++ b/source/WaDEApiFunctions/FunctionBase.cs
@@ -29,8 +29,30 @@ public abstract class FunctionBase
 
         return data;
     }
+    
+    protected async Task<HttpResponseData> CreateErrorResponse(HttpRequestData request, ErrorBase error)
+    {
+        return error switch
+        {
+            InternalError => await CreateInternalServerErrorResponse(request),
+            ValidationError err => await CreateBadRequestResponse(request, err),
+            _ => await CreateInternalServerErrorResponse(request)
+        };
+    }
+    
+    private Task<HttpResponseData> CreateInternalServerErrorResponse(HttpRequestData request)
+    {
+        var details = new ProblemDetails
+        {
+            Status = (int) HttpStatusCode.InternalServerError,
+            Title = "An unexpected error has occurred.",
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1"
+        };
 
-    protected static Task<HttpResponseData> CreateBadRequestResponse(HttpRequestData request, ValidationError error)
+        return CreateProblemDetailsResponse(request, details, HttpStatusCode.InternalServerError);
+    }
+
+    private static Task<HttpResponseData> CreateBadRequestResponse(HttpRequestData request, ValidationError error)
     {
         var details = new HttpValidationProblemDetails(error.Errors)
         {

--- a/source/WaDEApiFunctions/v1/WaterAllocation_AggregatedAmounts.cs
+++ b/source/WaDEApiFunctions/v1/WaterAllocation_AggregatedAmounts.cs
@@ -49,7 +49,7 @@ namespace WaDEApiFunctions.v1
 
             if (startIndex < 0)
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("StartIndex", ["StartIndex must be 0 or greater."])
                 );
@@ -57,7 +57,7 @@ namespace WaDEApiFunctions.v1
 
             if (recordCount is < 1 or > 10000)
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("RecordCount", ["RecordCount must be between 1 and 10000"])
                 );
@@ -72,7 +72,7 @@ namespace WaDEApiFunctions.v1
                 string.IsNullOrWhiteSpace(usgsCategoryNameCV) &&
                 string.IsNullOrWhiteSpace(state))
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError(
                         "Filters",
@@ -106,9 +106,10 @@ namespace WaDEApiFunctions.v1
 
             var response = await _waterResourceManager
                 .Load<AggregatedAmountsSearchRequest, AggregatedAmountsSearchResponse>(searchRequest);
-            
-            // todo if error, return error response?
-            return await CreateOkResponse(req, response.AggregatedAmounts);
+
+            return response.Error is null
+                ? await CreateOkResponse(req, response.AggregatedAmounts)
+                : await CreateErrorResponse(req, response.Error);
         }
 
         private sealed class AggregratedAmountsRequestBody

--- a/source/WaDEApiFunctions/v1/WaterAllocation_AggregatedAmounts.cs
+++ b/source/WaDEApiFunctions/v1/WaterAllocation_AggregatedAmounts.cs
@@ -104,10 +104,11 @@ namespace WaDEApiFunctions.v1
                 OutputGeometryFormat = geoFormat
             };
 
-            var siteAllocationAmounts = await _waterResourceManager
+            var response = await _waterResourceManager
                 .Load<AggregatedAmountsSearchRequest, AggregatedAmountsSearchResponse>(searchRequest);
             
-            return await CreateOkResponse(req, siteAllocationAmounts);
+            // todo if error, return error response?
+            return await CreateOkResponse(req, response.AggregatedAmounts);
         }
 
         private sealed class AggregratedAmountsRequestBody

--- a/source/WaDEApiFunctions/v1/WaterAllocation_RegulatoryOverlay.cs
+++ b/source/WaDEApiFunctions/v1/WaterAllocation_RegulatoryOverlay.cs
@@ -96,10 +96,11 @@ namespace WaDEApiFunctions.v1
                 OutputGeometryFormat = geoFormat
             };
 
-            var regulatoryReportingUnits = await _waterResourceManager
+            var response = await _waterResourceManager
                 .Load<OverlayResourceSearchRequest, OverlayResourceSearchResponse>(request);
             
-            return await CreateOkResponse(req, regulatoryReportingUnits);
+            // todo if error, return error response?
+            return await CreateOkResponse(req, response.ReportingUnits);
         }
 
         private sealed class RegulatoryOverlayRequestBody

--- a/source/WaDEApiFunctions/v1/WaterAllocation_RegulatoryOverlay.cs
+++ b/source/WaDEApiFunctions/v1/WaterAllocation_RegulatoryOverlay.cs
@@ -6,7 +6,6 @@ using Microsoft.Azure.Functions.Worker.Http;
 using WesternStatesWater.Shared.Errors;
 using WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
 using WesternStatesWater.WaDE.Contracts.Api.Responses.V1;
-using WesternStatesWater.WaDE.Contracts.Api.Responses.V2;
 
 namespace WaDEApiFunctions.v1
 {
@@ -49,7 +48,7 @@ namespace WaDEApiFunctions.v1
 
             if (startIndex < 0)
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("StartIndex", ["StartIndex must be 0 or greater."])
                 );
@@ -57,7 +56,7 @@ namespace WaDEApiFunctions.v1
 
             if (recordCount is < 1 or > 10000)
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("RecordCount", ["RecordCount must be between 1 and 10000"])
                 );
@@ -70,7 +69,7 @@ namespace WaDEApiFunctions.v1
                 string.IsNullOrWhiteSpace(geometry) &&
                 string.IsNullOrWhiteSpace(state))
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("Filters", ["At least one of the following filter parameters must be specified: reportingUnitUUID, regulatoryOverlayUUID, organizationUUID, regulatoryStatusCV, geometry, state"])
                 );
@@ -98,9 +97,10 @@ namespace WaDEApiFunctions.v1
 
             var response = await _waterResourceManager
                 .Load<OverlayResourceSearchRequest, OverlayResourceSearchResponse>(request);
-            
-            // todo if error, return error response?
-            return await CreateOkResponse(req, response.ReportingUnits);
+
+            return response.Error is null
+                ? await CreateOkResponse(req, response.ReportingUnits)
+                : await CreateErrorResponse(req, response.Error);
         }
 
         private sealed class RegulatoryOverlayRequestBody

--- a/source/WaDEApiFunctions/v1/WaterAllocation_SiteAllocationAmounts.cs
+++ b/source/WaDEApiFunctions/v1/WaterAllocation_SiteAllocationAmounts.cs
@@ -51,7 +51,7 @@ namespace WaDEApiFunctions.v1
 
             if (startIndex < 0)
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("StartIndex", ["StartIndex must be 0 or greater."])
                 );
@@ -59,7 +59,7 @@ namespace WaDEApiFunctions.v1
 
             if (recordCount is < 1 or > 10000)
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("RecordCount", ["RecordCount must be between 1 and 10000"])
                 );
@@ -75,7 +75,7 @@ namespace WaDEApiFunctions.v1
                 string.IsNullOrWhiteSpace(county) &&
                 string.IsNullOrWhiteSpace(state))
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("Filters",
                     [
@@ -110,8 +110,9 @@ namespace WaDEApiFunctions.v1
             var response = await _waterResourceManager
                 .Load<SiteAllocationAmountsSearchRequest, SiteAllocationAmountsSearchResponse>(request);
 
-            // todo if error, return error response?
-            return await CreateOkResponse(req, response.WaterAllocations);
+            return response.Error is null
+                ? await CreateOkResponse(req, response.WaterAllocations)
+                : await CreateErrorResponse(req, response.Error);
         }
 
         [Function("WaterAllocation_SiteAllocationAmountsDigest_v1")]
@@ -136,7 +137,7 @@ namespace WaDEApiFunctions.v1
 
             if (startIndex < 0)
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("StartIndex", ["StartIndex must be 0 or greater."])
                 );
@@ -144,7 +145,7 @@ namespace WaDEApiFunctions.v1
 
             if (recordCount is < 1 or > 10000)
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("RecordCount", ["RecordCount must be between 1 and 10000"])
                 );
@@ -156,7 +157,7 @@ namespace WaDEApiFunctions.v1
                 string.IsNullOrWhiteSpace(siteTypeCV) &&
                 string.IsNullOrWhiteSpace(usgsCategoryNameCV))
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError("Filters",
                     [
@@ -186,8 +187,9 @@ namespace WaDEApiFunctions.v1
             var response = await _waterResourceManager
                 .Load<SiteAllocationAmountsDigestSearchRequest, SiteAllocationAmountsDigestSearchResponse>(request);
 
-            // todo if error, return error response?
-            return await CreateOkResponse(req, response.WaterAllocationDigests);
+            return response.Error is null
+                ? await CreateOkResponse(req, response.WaterAllocationDigests)
+                : await CreateErrorResponse(req, response.Error);
         }
 
         private sealed class SiteAllocationAmountsRequestBody

--- a/source/WaDEApiFunctions/v1/WaterAllocation_SiteVariableAmounts.cs
+++ b/source/WaDEApiFunctions/v1/WaterAllocation_SiteVariableAmounts.cs
@@ -62,7 +62,7 @@ namespace WaDEApiFunctions.v1
                 string.IsNullOrWhiteSpace(county) &&
                 string.IsNullOrWhiteSpace(state))
             {
-                return await CreateBadRequestResponse(
+                return await CreateErrorResponse(
                     req,
                     new ValidationError(
                         "Filters",
@@ -99,9 +99,10 @@ namespace WaDEApiFunctions.v1
 
             var response = await _waterResourceManager
                 .Load<SiteVariableAmountsSearchRequest, SiteVariableAmountsSearchResponse>(request);
-            
-            // todo if error, return error response?
-            return await CreateOkResponse(req, response.SiteVariableAmounts);
+
+            return response.Error is null
+                ? await CreateOkResponse(req, response.SiteVariableAmounts)
+                : await CreateErrorResponse(req, response.Error);
         }
 
         private sealed class AggregratedAmountsRequestBody

--- a/source/WaDEApiFunctions/v1/WaterAllocation_SiteVariableAmounts.cs
+++ b/source/WaDEApiFunctions/v1/WaterAllocation_SiteVariableAmounts.cs
@@ -97,10 +97,11 @@ namespace WaDEApiFunctions.v1
                 OutputGeometryFormat = geoFormat
             };
 
-            var siteAllocationAmounts = await _waterResourceManager
+            var response = await _waterResourceManager
                 .Load<SiteVariableAmountsSearchRequest, SiteVariableAmountsSearchResponse>(request);
             
-            return await CreateOkResponse(req, siteAllocationAmounts);
+            // todo if error, return error response?
+            return await CreateOkResponse(req, response.SiteVariableAmounts);
         }
 
         private sealed class AggregratedAmountsRequestBody

--- a/source/WesternStatesWater.WaDE.Clients.Tests/v1/WaterAllocationSiteAllocationAmountsTests.cs
+++ b/source/WesternStatesWater.WaDE.Clients.Tests/v1/WaterAllocationSiteAllocationAmountsTests.cs
@@ -9,18 +9,20 @@ using Telerik.JustMock;
 using Telerik.JustMock.Helpers;
 using WaDEApiFunctions.v1;
 using WesternStatesWater.WaDE.Contracts.Api;
+using WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
+using WesternStatesWater.WaDE.Contracts.Api.Responses.V1;
 
 namespace WesternStatesWater.WaDE.Clients.Tests.v1
 {
     [TestClass]
     public class WaterAllocationSiteAllocationAmountsTests : FunctionTestBase
     {
-        private IWaterAllocationManager _waterAllocationManagerMock = null!;
+        private IWaterResourceManager _waterResourceManagerMock = null!;
 
         [TestInitialize]
         public void TestInitialize()
         {
-            _waterAllocationManagerMock = Mock.Create<IWaterAllocationManager>(Behavior.Strict);
+            _waterResourceManagerMock = Mock.Create<IWaterResourceManager>(Behavior.Strict);
         }
 
         [DataTestMethod]
@@ -40,8 +42,15 @@ namespace WesternStatesWater.WaDE.Clients.Tests.v1
         public async Task Run_GeometryFormat(string formatString, GeometryFormat expectedGeometryFormat)
         {
             var faker = new Faker();
-            _waterAllocationManagerMock.Arrange(a => a.GetSiteAllocationAmountsAsync(Arg.IsAny<SiteAllocationAmountsFilters>(), 0, 1000, expectedGeometryFormat))
-                .Returns(Task.FromResult(new WaterAllocations()));
+
+            _waterResourceManagerMock
+                .Arrange(mgr => mgr.Load<SiteAllocationAmountsSearchRequest, SiteAllocationAmountsSearchResponse>(
+                    Arg.Matches<SiteAllocationAmountsSearchRequest>(req =>
+                        req.StartIndex == 0 &&
+                        req.RecordCount == 1000 &&
+                        req.OutputGeometryFormat == expectedGeometryFormat
+                    )))
+                .ReturnsAsync(new SiteAllocationAmountsSearchResponse { WaterAllocations = new WaterAllocations() });
 
             var context = Mock.Create<FunctionContext>();
             var request = new FakeHttpRequestData(context, new Uri($"http://localhost?SiteUUID={faker.Random.Uuid()}&geoFormat={formatString}"));
@@ -50,7 +59,13 @@ namespace WesternStatesWater.WaDE.Clients.Tests.v1
             var result = await sut.Run(request);
             result.StatusCode.Should().Be(HttpStatusCode.OK);
 
-            _waterAllocationManagerMock.Assert(a => a.GetSiteAllocationAmountsAsync(Arg.IsAny<SiteAllocationAmountsFilters>(), 0, 1000, expectedGeometryFormat), Occurs.Once());
+            _waterResourceManagerMock.Assert(a =>
+                a.Load<SiteAllocationAmountsSearchRequest, SiteAllocationAmountsSearchResponse>(
+                    Arg.Matches<SiteAllocationAmountsSearchRequest>(req =>
+                        req.StartIndex == 0 &&
+                        req.RecordCount == 1000 &&
+                        req.OutputGeometryFormat == expectedGeometryFormat
+                    )), Occurs.Once());
         }
 
         [DataTestMethod]
@@ -61,8 +76,14 @@ namespace WesternStatesWater.WaDE.Clients.Tests.v1
         [DataRow("good one", HttpStatusCode.OK)]
         public async Task Run_SiteUuid(string siteUuid, HttpStatusCode expectedHttpStatusCode)
         {
-            _waterAllocationManagerMock.Arrange(a => a.GetSiteAllocationAmountsAsync(Arg.IsAny<SiteAllocationAmountsFilters>(), 0, 1000, GeometryFormat.Wkt))
-                .Returns(Task.FromResult(new WaterAllocations()));
+            _waterResourceManagerMock
+                .Arrange(mgr => mgr.Load<SiteAllocationAmountsSearchRequest, SiteAllocationAmountsSearchResponse>(
+                    Arg.Matches<SiteAllocationAmountsSearchRequest>(req =>
+                        req.StartIndex == 0 &&
+                        req.RecordCount == 1000 &&
+                        req.OutputGeometryFormat == GeometryFormat.Wkt
+                    )))
+                .ReturnsAsync(new SiteAllocationAmountsSearchResponse { WaterAllocations = new WaterAllocations() });
 
             var context = Mock.Create<FunctionContext>();
             var request = new FakeHttpRequestData(context, new Uri($"http://localhost?SiteUUID={siteUuid}"));
@@ -73,19 +94,31 @@ namespace WesternStatesWater.WaDE.Clients.Tests.v1
 
             if (expectedHttpStatusCode == HttpStatusCode.BadRequest)
             {
-                _waterAllocationManagerMock.Assert(a => a.GetSiteAllocationAmountsAsync(Arg.IsAny<SiteAllocationAmountsFilters>(), 0, 1000, GeometryFormat.Wkt), Occurs.Never());
+                _waterResourceManagerMock.Assert(a =>
+                    a.Load<SiteAllocationAmountsSearchRequest, SiteAllocationAmountsSearchResponse>(
+                        Arg.Matches<SiteAllocationAmountsSearchRequest>(req =>
+                            req.StartIndex == 0 &&
+                            req.RecordCount == 1000 &&
+                            req.OutputGeometryFormat == GeometryFormat.Wkt
+                        )), Occurs.Never());
             }
             else
             {
-                _waterAllocationManagerMock.Assert(a => a.GetSiteAllocationAmountsAsync(Arg.IsAny<SiteAllocationAmountsFilters>(), 0, 1000, GeometryFormat.Wkt), Occurs.Once());
-                _waterAllocationManagerMock.Assert(a => a.GetSiteAllocationAmountsAsync(Arg.Matches<SiteAllocationAmountsFilters>(f => f.SiteUuid == siteUuid), 0, 1000, GeometryFormat.Wkt), Occurs.Once());
+                _waterResourceManagerMock.Assert(a =>
+                    a.Load<SiteAllocationAmountsSearchRequest, SiteAllocationAmountsSearchResponse>(
+                        Arg.Matches<SiteAllocationAmountsSearchRequest>(req =>
+                            req.Filters.SiteUuid == siteUuid &&
+                            req.StartIndex == 0 &&
+                            req.RecordCount == 1000 &&
+                            req.OutputGeometryFormat == GeometryFormat.Wkt
+                        )), Occurs.Once());
             }
         }
 
         private WaterAllocation_SiteAllocationAmounts CreateSiteAllocationAmountsFunction()
         {
             return new WaterAllocation_SiteAllocationAmounts(
-                _waterAllocationManagerMock,
+                _waterResourceManagerMock,
                 CreateLogger<WaterAllocation_SiteAllocationAmounts>()
             );
         }

--- a/source/WesternStatesWater.WaDE.Contracts.Api/IWaterAllocationManager.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/IWaterAllocationManager.cs
@@ -1,12 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace WesternStatesWater.WaDE.Contracts.Api
 {
     public interface IWaterAllocationManager
     {
-        Task<WaterAllocations> GetSiteAllocationAmountsAsync(SiteAllocationAmountsFilters filters, int startIndex, int recordCount, GeometryFormat outputGeometryFormat);
-        Task<IEnumerable<WaterAllocationDigest>> GetSiteAllocationAmountsDigestAsync(SiteAllocationAmountsDigestFilters siteAllocationAmountsLightFilters, int startIndex, int recordCount);
         Task<OgcApi.CollectionsResponse> Collections();
     }
 }

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V1/SiteAllocationAmountsDigestSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V1/SiteAllocationAmountsDigestSearchRequest.cs
@@ -1,0 +1,10 @@
+namespace WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
+
+public class SiteAllocationAmountsDigestSearchRequest : WaterResourceLoadRequestBase
+{
+    public required SiteAllocationAmountsDigestFilters Filters { get; init; }
+
+    public int StartIndex { get; init; }
+
+    public int RecordCount { get; init; }
+}

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V1/SiteAllocationAmountsDigestSearchRequestValidator.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V1/SiteAllocationAmountsDigestSearchRequestValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
+
+public class SiteAllocationAmountsDigestSearchRequestValidator
+    : AbstractValidator<SiteAllocationAmountsDigestSearchRequest>
+{
+    public SiteAllocationAmountsDigestSearchRequestValidator()
+    {
+        // This class is necessary to use our newer patterns but is empty for legacy
+        // reasons (the validation is done in the client).
+    }
+}

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V1/SiteAllocationAmountsSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V1/SiteAllocationAmountsSearchRequest.cs
@@ -1,0 +1,12 @@
+namespace WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
+
+public class SiteAllocationAmountsSearchRequest : WaterResourceLoadRequestBase
+{
+    public required SiteAllocationAmountsFilters Filters { get; init; }
+
+    public int StartIndex { get; init; }
+
+    public int RecordCount { get; init; }
+
+    public GeometryFormat OutputGeometryFormat { get; init; }
+}

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V1/SiteAllocationAmountsSearchRequestValidator.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V1/SiteAllocationAmountsSearchRequestValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
+
+public class SiteAllocationAmountsSearchRequestValidator : AbstractValidator<SiteAllocationAmountsSearchRequest>
+{
+    public SiteAllocationAmountsSearchRequestValidator()
+    {
+        // This class is necessary to use our newer patterns but is empty for legacy
+        // reasons (the validation is done in the client).
+    }
+}

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Responses/V1/SiteAllocationAmountsDigestSearchResponse.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Responses/V1/SiteAllocationAmountsDigestSearchResponse.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace WesternStatesWater.WaDE.Contracts.Api.Responses.V1;
+
+public class SiteAllocationAmountsDigestSearchResponse : WaterResourceLoadResponseBase
+{
+    public required IEnumerable<WaterAllocationDigest> WaterAllocationDigests { get; init; }
+}

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Responses/V1/SiteAllocationAmountsSearchResponse.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Responses/V1/SiteAllocationAmountsSearchResponse.cs
@@ -1,0 +1,6 @@
+namespace WesternStatesWater.WaDE.Contracts.Api.Responses.V1;
+
+public class SiteAllocationAmountsSearchResponse : WaterResourceLoadResponseBase
+{
+    public required WaterAllocations WaterAllocations { get; init; }
+}

--- a/source/WesternStatesWater.WaDE.Managers.Api/Handlers/V1/SiteAllocationAmountsDigestSearchRequestHandler.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Handlers/V1/SiteAllocationAmountsDigestSearchRequestHandler.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WesternStatesWater.Shared.Resolver;
+using WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
+using WesternStatesWater.WaDE.Contracts.Api.Responses.V1;
+using WesternStatesWater.WaDE.Managers.Mapping;
+
+namespace WesternStatesWater.WaDE.Managers.Api.Handlers.V1;
+
+public class SiteAllocationAmountsDigestSearchRequestHandler
+    : IRequestHandler<SiteAllocationAmountsDigestSearchRequest, SiteAllocationAmountsDigestSearchResponse>
+{
+    private readonly AccessorApi.IWaterAllocationAccessor _waterAllocationAccessor;
+
+    public SiteAllocationAmountsDigestSearchRequestHandler(AccessorApi.IWaterAllocationAccessor waterAllocationAccessor)
+    {
+        _waterAllocationAccessor = waterAllocationAccessor;
+    }
+
+    public async Task<SiteAllocationAmountsDigestSearchResponse> Handle(
+        SiteAllocationAmountsDigestSearchRequest request
+    )
+    {
+        var filters = request.Filters.Map<AccessorApi.SiteAllocationAmountsDigestFilters>();
+
+        var dtoAllocationDigests = await _waterAllocationAccessor
+            .GetSiteAllocationAmountsDigestAsync(filters, request.StartIndex, request.RecordCount);
+
+        var apiAllocationDigests = dtoAllocationDigests.Map<IEnumerable<ManagerApi.WaterAllocationDigest>>();
+
+        return new SiteAllocationAmountsDigestSearchResponse { WaterAllocationDigests = apiAllocationDigests };
+    }
+}

--- a/source/WesternStatesWater.WaDE.Managers.Api/Handlers/V1/SiteAllocationAmountsSearchRequestHandler.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Handlers/V1/SiteAllocationAmountsSearchRequestHandler.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using WesternStatesWater.Shared.Resolver;
+using WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
+using WesternStatesWater.WaDE.Contracts.Api.Responses.V1;
+using WesternStatesWater.WaDE.Managers.Api.Mapping;
+using WesternStatesWater.WaDE.Managers.Mapping;
+
+namespace WesternStatesWater.WaDE.Managers.Api.Handlers.V1;
+
+public class SiteAllocationAmountsSearchRequestHandler
+    : IRequestHandler<SiteAllocationAmountsSearchRequest, SiteAllocationAmountsSearchResponse>
+{
+    private readonly AccessorApi.IWaterAllocationAccessor _waterAllocationAccessor;
+
+    public SiteAllocationAmountsSearchRequestHandler(AccessorApi.IWaterAllocationAccessor waterAllocationAccessor)
+    {
+        _waterAllocationAccessor = waterAllocationAccessor;
+    }
+
+    public async Task<SiteAllocationAmountsSearchResponse> Handle(SiteAllocationAmountsSearchRequest request)
+    {
+        var filters = request.Filters.Map<AccessorApi.SiteAllocationAmountsFilters>();
+
+        var dtoAmounts = await _waterAllocationAccessor.GetSiteAllocationAmountsAsync(
+            filters, request.StartIndex, request.RecordCount
+        );
+
+        var apiAmounts = dtoAmounts.Map<ManagerApi.WaterAllocations>(options =>
+            options.Items.Add(ApiProfile.GeometryFormatKey, request.OutputGeometryFormat)
+        );
+
+        return new SiteAllocationAmountsSearchResponse { WaterAllocations = apiAmounts };
+    }
+}

--- a/source/WesternStatesWater.WaDE.Managers.Api/WaterAllocationManager.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/WaterAllocationManager.cs
@@ -1,27 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using WesternStatesWater.WaDE.Contracts.Api;
 using WesternStatesWater.WaDE.Engines.Contracts.Ogc.Requests;
 using WesternStatesWater.WaDE.Engines.Contracts.Ogc.Responses;
-using WesternStatesWater.WaDE.Managers.Api.Mapping;
 using WesternStatesWater.WaDE.Managers.Mapping;
 
 namespace WesternStatesWater.WaDE.Managers.Api
 {
     internal partial class WaterResourceManager : IWaterAllocationManager
-    {   
-        async Task<WaterAllocations> IWaterAllocationManager.GetSiteAllocationAmountsAsync(SiteAllocationAmountsFilters filters, int startIndex, int recordCount, GeometryFormat outputGeometryFormat)
-        {
-            var results = await _waterAllocationAccessor.GetSiteAllocationAmountsAsync(filters.Map<AccessorApi.SiteAllocationAmountsFilters>(), startIndex, recordCount);
-            return results.Map<WaterAllocations>(a => a.Items.Add(ApiProfile.GeometryFormatKey, outputGeometryFormat));
-        }
-
-        async Task<IEnumerable<WaterAllocationDigest>> IWaterAllocationManager.GetSiteAllocationAmountsDigestAsync(SiteAllocationAmountsDigestFilters filters, int startIndex, int recordCount)
-        {
-            var results = await _waterAllocationAccessor.GetSiteAllocationAmountsDigestAsync(filters.Map<AccessorApi.SiteAllocationAmountsDigestFilters>(), startIndex, recordCount);
-            return results.Map<IEnumerable<WaterAllocationDigest>>();
-        }
-
+    {
         async Task<Contracts.Api.OgcApi.CollectionsResponse> IWaterAllocationManager.Collections()
         {
             var request = new CollectionsRequest();

--- a/source/WesternStatesWater.WaDE.Managers.Api/WaterResourceManager.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/WaterResourceManager.cs
@@ -9,20 +9,16 @@ internal partial class WaterResourceManager : ManagerBase, ManagerApi.IMetadataM
 {
     private readonly IFormattingEngine _formattingEngine;
 
-    private readonly AccessorApi.ISiteVariableAmountsAccessor _siteVariableAmountsAccessor;
-
     private readonly AccessorApi.IWaterAllocationAccessor _waterAllocationAccessor;
 
     public WaterResourceManager(
         IManagerRequestHandlerResolver requestHandlerResolver,
         IFormattingEngine formattingEngine,
-        AccessorApi.ISiteVariableAmountsAccessor siteVariableAmountsAccessor,
         AccessorApi.IWaterAllocationAccessor waterAllocationAccessor,
         ILogger<WaterResourceManager> logger)
         : base(logger, requestHandlerResolver)
     {
         _formattingEngine = formattingEngine;
-        _siteVariableAmountsAccessor = siteVariableAmountsAccessor;
         _waterAllocationAccessor = waterAllocationAccessor;
     }
 

--- a/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/HandlerTestsBase.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/HandlerTestsBase.cs
@@ -13,4 +13,7 @@ public abstract class HandlerTestsBase
 
     protected ISiteVariableAmountsAccessor SiteVariableAmountsAccessorMock { get; } =
         Mock.Create<ISiteVariableAmountsAccessor>(Behavior.Strict);
+
+    protected IWaterAllocationAccessor WaterAllocationAccessorMock { get; } =
+        Mock.Create<IWaterAllocationAccessor>(Behavior.Strict);
 }

--- a/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V1/SiteAllocationAmountsSearchRequestHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V1/SiteAllocationAmountsSearchRequestHandlerTests.cs
@@ -5,13 +5,15 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Telerik.JustMock;
 using Telerik.JustMock.Helpers;
 using WesternStatesWater.WaDE.Contracts.Api;
+using WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
+using WesternStatesWater.WaDE.Managers.Api.Handlers.V1;
 using WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Api;
 using WesternStatesWater.WaDE.Utilities;
 
-namespace WesternStatesWater.WaDE.Managers.Tests.WaterResourceManager
+namespace WesternStatesWater.WaDE.Managers.Tests.Handlers.V1
 {
     [TestClass]
-    public class ApiWaterAllocationManagerTests : WaterResourceManagerTestsBase 
+    public class SiteAllocationAmountsSearchRequestHandlerTests : HandlerTestsBase 
     {
         [DataTestMethod]
         [DataRow(null, GeometryFormat.Wkt, null)]
@@ -24,11 +26,20 @@ namespace WesternStatesWater.WaDE.Managers.Tests.WaterResourceManager
             accessorResult.Organizations.First().Sites[0].SiteGeometry = GeometryExtensions.GetGeometryByWkt(geometryString);
             WaterAllocationAccessorMock.Arrange(a => a.GetSiteAllocationAmountsAsync(Arg.IsAny<Accessors.Contracts.Api.SiteAllocationAmountsFilters>(), 0, 1))
                                        .Returns(Task.FromResult(accessorResult));
-            var sut = CreateWaterAllocationManager();
-            var result = await sut.GetSiteAllocationAmountsAsync(new Contracts.Api.SiteAllocationAmountsFilters(), 0, 1, geometryFormat);
+            var sut = CreateHandler();
+
+            var request = new SiteAllocationAmountsSearchRequest
+            {
+                Filters = new SiteAllocationAmountsFilters(),
+                StartIndex = 0,
+                RecordCount = 1,
+                OutputGeometryFormat = geometryFormat
+            };
+
+            var result = await sut.Handle(request);
             result.Should().NotBeNull();
 
-            var resultGeometry = result.Organizations.First().Sites[0].SiteGeometry;
+            var resultGeometry = result.WaterAllocations.Organizations.First().Sites[0].SiteGeometry;
             if (expectedResultString == null)
             {
                 resultGeometry.Should().BeNull();
@@ -51,11 +62,20 @@ namespace WesternStatesWater.WaDE.Managers.Tests.WaterResourceManager
             accessorResult.Organizations.First().WaterSources[0].WaterSourceGeometry = GeometryExtensions.GetGeometryByWkt(geometryString);
             WaterAllocationAccessorMock.Arrange(a => a.GetSiteAllocationAmountsAsync(Arg.IsAny<Accessors.Contracts.Api.SiteAllocationAmountsFilters>(), 0, 1))
                                        .Returns(Task.FromResult(accessorResult));
-            var sut = CreateWaterAllocationManager();
-            var result = await sut.GetSiteAllocationAmountsAsync(new Contracts.Api.SiteAllocationAmountsFilters(), 0, 1, geometryFormat);
+            var sut = CreateHandler();
+            
+            var request = new SiteAllocationAmountsSearchRequest
+            {
+                Filters = new SiteAllocationAmountsFilters(),
+                StartIndex = 0,
+                RecordCount = 1,
+                OutputGeometryFormat = geometryFormat
+            };
+            
+            var result = await sut.Handle(request);
             result.Should().NotBeNull();
 
-            var resultGeometry = result.Organizations.First().WaterSources[0].WaterSourceGeometry;
+            var resultGeometry = result.WaterAllocations.Organizations.First().WaterSources[0].WaterSourceGeometry;
             if (expectedResultString == null)
             {
                 resultGeometry.Should().BeNull();
@@ -67,9 +87,9 @@ namespace WesternStatesWater.WaDE.Managers.Tests.WaterResourceManager
             }
         }
 
-        private IWaterAllocationManager CreateWaterAllocationManager()
+        private SiteAllocationAmountsSearchRequestHandler CreateHandler()
         {
-            return CreateWaterResourceManager();
+            return new SiteAllocationAmountsSearchRequestHandler(WaterAllocationAccessorMock);
         }
     }
 }

--- a/source/WesternStatesWater.WaDE.Managers.Tests/WaterResourceManager/WaterResourceManagerTestsBase.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/WaterResourceManager/WaterResourceManagerTestsBase.cs
@@ -9,9 +9,6 @@ namespace WesternStatesWater.WaDE.Managers.Tests.WaterResourceManager;
 
 public abstract class WaterResourceManagerTestsBase
 {
-    protected ISiteVariableAmountsAccessor SiteVariableAmountsAccessorMock { get; } =
-        Mock.Create<ISiteVariableAmountsAccessor>(Behavior.Strict);
-
     protected IWaterAllocationAccessor WaterAllocationAccessorMock { get; } =
         Mock.Create<IWaterAllocationAccessor>(Behavior.Strict);
 
@@ -29,7 +26,6 @@ public abstract class WaterResourceManagerTestsBase
         return new Api.WaterResourceManager(
             Mock.Create<IManagerRequestHandlerResolver>(Behavior.Strict),
             FormattingEngineMock,
-            SiteVariableAmountsAccessorMock,
             WaterAllocationAccessorMock,
             logger
         );


### PR DESCRIPTION
This PR moves the last v1 (site allocation amounts) endpoints over to using the handler pattern and fixes some nested object response issues introduced in the previous coupe PRs. Also, improves error response handling.