### PR TITLE
Reworked Faker CV Builders

### DIFF
--- a/source/WesternStatesWater.WaDE.Accessors.Tests/DbTestBase.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/DbTestBase.cs
@@ -12,7 +12,10 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            TransactionScope = new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled);
+            TransactionScope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions
+            {
+                IsolationLevel = IsolationLevel.ReadUncommitted,
+            }, TransactionScopeAsyncFlowOption.Enabled);
         }
 
 

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AggregationStatistic.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/AggregationStatistic.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class AggregationStatistic
+    public partial class AggregationStatistic : ControlledVocabularyBase
     {
         public AggregationStatistic()
         {
             VariablesDim = new HashSet<VariablesDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<VariablesDim> VariablesDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ApplicableResourceType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ApplicableResourceType.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class ApplicableResourceType
+    public partial class ApplicableResourceType : ControlledVocabularyBase
     {
         public ApplicableResourceType()
         {
             MethodsDim = new HashSet<MethodsDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<MethodsDim> MethodsDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/BeneficialUsesCV.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/BeneficialUsesCV.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class BeneficialUsesCV
+    public partial class BeneficialUsesCV : ControlledVocabularyBase
     {
         public BeneficialUsesCV()
         {
@@ -12,27 +11,16 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
             AllocationBridgeBeneficialUsesFact = new HashSet<AllocationBridgeBeneficialUsesFact>();
             SitesBridgeBeneficialUsesFact = new HashSet<SitesBridgeBeneficialUsesFact>();
             SiteVariableAmountsFact = new HashSet<SiteVariableAmountsFact>();
-            
         }
-
-        
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-
-        public string SourceVocabularyURI { get; set; }
 
         public string UsgscategoryNameCv { get; set; }
         public string NaicscodeNameCv { get; set; }
 
-        
+
         public virtual ICollection<AggBridgeBeneficialUsesFact> AggBridgeBeneficialUsesFact { get; set; }
         public virtual ICollection<AggregatedAmountsFact> AggregatedAmountsFact { get; set; }
         public virtual ICollection<AllocationBridgeBeneficialUsesFact> AllocationBridgeBeneficialUsesFact { get; set; }
         public virtual ICollection<SitesBridgeBeneficialUsesFact> SitesBridgeBeneficialUsesFact { get; set; }
         public virtual ICollection<SiteVariableAmountsFact> SiteVariableAmountsFact { get; set; }
-
-
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ControlledVocabularyBase.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ControlledVocabularyBase.cs
@@ -1,0 +1,11 @@
+namespace WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+public abstract class ControlledVocabularyBase
+{
+    public string Name { get; set; }
+    public string Term { get; set; }
+    public string Definition { get; set; }
+    public string State { get; set; }
+    public string SourceVocabularyUri { get; set; }
+    public string WaDEName { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/CoordinateMethod.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/CoordinateMethod.cs
@@ -1,26 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class CoordinateMethod
+    public partial class CoordinateMethod : ControlledVocabularyBase
     {
         public CoordinateMethod()
         {
             SitesDim = new HashSet<SitesDim>();
         }
-
-        [MaxLength(100)]
-        public string Name { get; set; }
-        [MaxLength(2)]
-        public string Term { get; set; }
-        [MaxLength(10)]
-        public string Definition { get; set; }
-        [MaxLength(10)]
-        public string State { get; set; }
-        [MaxLength(100)]
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<SitesDim> SitesDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/CropType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/CropType.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class CropType
+    public partial class CropType : ControlledVocabularyBase
     {
         public CropType()
         {
@@ -12,17 +11,9 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
             AggregatedAmountsFact = new HashSet<AggregatedAmountsFact>();
         }
 
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
-
         public virtual ICollection<SiteVariableAmountsFact> SiteVariableAmountsFact { get; set; }
         public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }
 
         public virtual ICollection<AggregatedAmountsFact> AggregatedAmountsFact { get; set; }
-
-
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/CustomerType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/CustomerType.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class CustomerType
+    public partial class CustomerType : ControlledVocabularyBase
     {
         public CustomerType()
         {
@@ -11,12 +10,6 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
             AllocationAmountsFact = new HashSet<AllocationAmountsFact>();
             AggregatedAmountsFact = new HashSet<AggregatedAmountsFact>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<SiteVariableAmountsFact> SiteVariableAmountsFact { get; set; }
         public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/DataQualityValue.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/DataQualityValue.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class DataQualityValue
+    public partial class DataQualityValue : ControlledVocabularyBase
     {
         public DataQualityValue()
         {
             MethodsDim = new HashSet<MethodsDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<MethodsDim> MethodsDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/Epsgcode.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/Epsgcode.cs
@@ -1,27 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class Epsgcode
+    public partial class Epsgcode : ControlledVocabularyBase
     {
         public Epsgcode()
         {
             ReportingUnitsDim = new HashSet<ReportingUnitsDim>();
             SitesDim = new HashSet<SitesDim>();
         }
-
-        [MaxLength(50)]
-        public string Name { get; set; }
-        [MaxLength(250)]
-        public string Term { get; set; }
-        [MaxLength(4000)]
-        public string Definition { get; set; }
-        [MaxLength(250)]
-        public string State { get; set; }
-        [MaxLength(250)]
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<ReportingUnitsDim> ReportingUnitsDim { get; set; }
         public virtual ICollection<SitesDim> SitesDim { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/GnisfeatureName.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/GnisfeatureName.cs
@@ -1,27 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class GnisfeatureName
+    public partial class GnisfeatureName : ControlledVocabularyBase
     {
         public GnisfeatureName()
         {
             SitesDim = new HashSet<SitesDim>();
             WaterSourcesDim = new HashSet<WaterSourcesDim>();
         }
-
-        [MaxLength(250)]
-        public string Name { get; set; }
-        [MaxLength(250)] 
-        public string Term { get; set; }
-        [MaxLength(4000)] 
-        public string Definition { get; set; }
-        [MaxLength(250)]
-        public string State { get; set; }
-        [MaxLength(250)]
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<SitesDim> SitesDim { get; set; }
         public virtual ICollection<WaterSourcesDim> WaterSourcesDim { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/IrrigationMethod.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/IrrigationMethod.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class IrrigationMethod
+    public partial class IrrigationMethod : ControlledVocabularyBase
     {
         public IrrigationMethod()
         {
@@ -12,18 +11,10 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
             AggregatedAmountsFact = new HashSet<AggregatedAmountsFact>();
         }
 
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
-
         public virtual ICollection<SiteVariableAmountsFact> SiteVariableAmountsFact { get; set; }
 
         public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }
-       
+
         public virtual ICollection<AggregatedAmountsFact> AggregatedAmountsFact { get; set; }
-
-
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/LegalStatus.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/LegalStatus.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class LegalStatus
+    public partial class LegalStatus : ControlledVocabularyBase
     {
         public LegalStatus()
         {
             AllocationAmountsFact = new HashSet<AllocationAmountsFact>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/MethodType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/MethodType.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class MethodType
+    public partial class MethodType : ControlledVocabularyBase
     {
         public MethodType()
         {
             MethodsDim = new HashSet<MethodsDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<MethodsDim> MethodsDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/NhdnetworkStatus.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/NhdnetworkStatus.cs
@@ -1,25 +1,13 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class NhdnetworkStatus
+    public partial class NhdnetworkStatus : ControlledVocabularyBase
     {
         public NhdnetworkStatus()
         {
             SitesDim = new HashSet<SitesDim>();
         }
-
-        [MaxLength(50)]
-        public string Name { get; set; }
-        [MaxLength(250)]
-        public string Term { get; set; }
-        [MaxLength(4000)]
-        public string Definition { get; set; }
-        [MaxLength(250)]
-        public string State { get; set; }
-        [MaxLength(250)]
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<SitesDim> SitesDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/Nhdproduct.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/Nhdproduct.cs
@@ -1,25 +1,13 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class Nhdproduct
+    public partial class Nhdproduct : ControlledVocabularyBase
     {
         public Nhdproduct()
         {
             SitesDim = new HashSet<SitesDim>();
         }
-
-        [MaxLength(50)]
-        public string Name { get; set; }
-        [MaxLength(250)]
-        public string Term { get; set; }
-        [MaxLength(4000)]
-        public string Definition { get; set; }
-        [MaxLength(250)]
-        public string State { get; set; }
-        [MaxLength(250)]
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<SitesDim> SitesDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/OwnerClassificationCv.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/OwnerClassificationCv.cs
@@ -2,18 +2,12 @@
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class OwnerClassificationCv
+    public partial class OwnerClassificationCv : ControlledVocabularyBase
     {
         public OwnerClassificationCv()
         {
             AllocationAmountsFact = new HashSet<AllocationAmountsFact>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string State { get; set; }
-        public string Definition { get; set; }
-        public string SourceVocabularyURI { get; set; }
 
         public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/PowerType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/PowerType.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class PowerType
+    public partial class PowerType : ControlledVocabularyBase
     {
         public PowerType()
         {
@@ -12,17 +11,9 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
             AggregatedAmountsFact = new HashSet<AggregatedAmountsFact>();
         }
 
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
-
         public virtual ICollection<SiteVariableAmountsFact> SiteVariableAmountsFact { get; set; }
         public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }
 
         public virtual ICollection<AggregatedAmountsFact> AggregatedAmountsFact { get; set; }
-
-
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/RegulatoryOverlayType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/RegulatoryOverlayType.cs
@@ -2,18 +2,12 @@
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public class RegulatoryOverlayType
+    public partial class RegulatoryOverlayType : ControlledVocabularyBase
     {
         public RegulatoryOverlayType()
         {
             RegulatoryOverlayDim = new HashSet<RegulatoryOverlayDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<RegulatoryOverlayDim> RegulatoryOverlayDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/RegulatoryStatus.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/RegulatoryStatus.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace WesternStatesWater.WaDE.Accessors.EntityFramework
+﻿namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class RegulatoryStatus
+    public partial class RegulatoryStatus : ControlledVocabularyBase
     {
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string State { get; set; }
-        public string Definition { get; set; }
-        public string SourceVocabularyUri { get; set; }
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ReportYearCv.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ReportYearCv.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class ReportYearCv
+    public partial class ReportYearCv : ControlledVocabularyBase
     {
         public ReportYearCv()
         {
             AggregatedAmountsFact = new HashSet<AggregatedAmountsFact>();
             SiteVariableAmountsFact = new HashSet<SiteVariableAmountsFact>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<AggregatedAmountsFact> AggregatedAmountsFact { get; set; }
         public virtual ICollection<SiteVariableAmountsFact> SiteVariableAmountsFact { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ReportYearType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ReportYearType.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class ReportYearType
+    public partial class ReportYearType : ControlledVocabularyBase
     {
         public ReportYearType()
         {
             VariablesDim = new HashSet<VariablesDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<VariablesDim> VariablesDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ReportingUnitType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/ReportingUnitType.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class ReportingUnitType
+    public partial class ReportingUnitType : ControlledVocabularyBase
     {
         public ReportingUnitType()
         {
             ReportingUnitsDim = new HashSet<ReportingUnitsDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<ReportingUnitsDim> ReportingUnitsDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/SDWISIdentifier.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/SDWISIdentifier.cs
@@ -1,23 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class SDWISIdentifier
+    public partial class SDWISIdentifier : ControlledVocabularyBase
     {
         public SDWISIdentifier()
         {
-           AllocationAmountsFact = new HashSet<AllocationAmountsFact>();
-           SiteVariableAmountsFact = new HashSet<SiteVariableAmountsFact>();
-           AggregatedAmountsFact = new HashSet<AggregatedAmountsFact>();
-
+            AllocationAmountsFact = new HashSet<AllocationAmountsFact>();
+            SiteVariableAmountsFact = new HashSet<SiteVariableAmountsFact>();
+            AggregatedAmountsFact = new HashSet<AggregatedAmountsFact>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<SiteVariableAmountsFact> SiteVariableAmountsFact { get; set; }
         public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/SiteType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/SiteType.cs
@@ -1,25 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class SiteType
+    public partial class SiteType : ControlledVocabularyBase
     {
         public SiteType()
         {
             SitesDim = new HashSet<SitesDim>();
         }
-
-        [MaxLength(100)]
-        public string Name { get; set; }
-        [MaxLength(250)]
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        [MaxLength(250)]
-        public string State { get; set; }
-        [MaxLength(250)]
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<SitesDim> SitesDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/State.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/State.cs
@@ -1,27 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class State
+    public partial class State : ControlledVocabularyBase
     {
         public State()
         {
             ReportingUnitsDim = new HashSet<ReportingUnitsDim>();
             SitesDims = new HashSet<SitesDim>();
         }
-
-        [MaxLength(2)]
-        public string Name { get; set; }
-        [MaxLength(2)]
-        public string Term { get; set; }
-        [MaxLength(20)]
-        public string Definition { get; set; }
-        [MaxLength(10)]
-        public string State1 { get; set; }
-        [MaxLength(100)]
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<ReportingUnitsDim> ReportingUnitsDim { get; set; }
         public virtual ICollection<SitesDim> SitesDims { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/Units.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/Units.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class Units
+    public partial class Units : ControlledVocabularyBase
     {
         public Units()
         {
@@ -11,12 +10,6 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
             VariablesDimAmountUnitCvNavigation = new HashSet<VariablesDim>();
             VariablesDimMaximumAmountUnitCvNavigation = new HashSet<VariablesDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<VariablesDim> VariablesDimAggregationIntervalUnitCvNavigation { get; set; }
         public virtual ICollection<VariablesDim> VariablesDimAmountUnitCvNavigation { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/Variable.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/Variable.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class Variable
+    public partial class Variable : ControlledVocabularyBase
     {
         public Variable()
         {
             VariablesDim = new HashSet<VariablesDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<VariablesDim> VariablesDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/VariableSpecific.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/VariableSpecific.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class VariableSpecific
+    public partial class VariableSpecific : ControlledVocabularyBase
     {
         public VariableSpecific()
         {
             VariablesDim = new HashSet<VariablesDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<VariablesDim> VariablesDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
@@ -606,7 +606,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                 entity.Property(e => e.NaicscodeNameCv)
                    .HasColumnName("NAICSCode")
                    .HasMaxLength(100);
-                entity.Property(e => e.SourceVocabularyURI)
+                entity.Property(e => e.SourceVocabularyUri)
                    .HasColumnName("SourceVocabularyURI")
                    .HasMaxLength(100);
 
@@ -1059,7 +1059,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 
                 entity.Property(e => e.Definition).HasMaxLength(4000);
 
-                entity.Property(e => e.SourceVocabularyURI)
+                entity.Property(e => e.SourceVocabularyUri)
                     .HasColumnName("SourceVocabularyURI")
                     .HasMaxLength(250);
 
@@ -1740,7 +1740,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                     .HasColumnName("SourceVocabularyURI")
                     .HasMaxLength(100);
 
-                entity.Property(e => e.State1)
+                entity.Property(e => e.State)
                     .HasColumnName("State")
                     .HasMaxLength(10);
 

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaterAllocationBasis.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaterAllocationBasis.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class WaterAllocationBasis
+    public partial class WaterAllocationBasis : ControlledVocabularyBase
     {
         public WaterAllocationBasis()
         {
             AllocationAmountsFact = new HashSet<AllocationAmountsFact>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string State { get; set; }
-        public string Definition { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaterAllocationType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaterAllocationType.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class WaterAllocationType
+    public partial class WaterAllocationType : ControlledVocabularyBase
     {
         public WaterAllocationType()
         {
             AllocationAmountsFact = new HashSet<AllocationAmountsFact>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string State { get; set; }
-        public string Definition { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<AllocationAmountsFact> AllocationAmountsFact { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaterQualityIndicator.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaterQualityIndicator.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class WaterQualityIndicator
+    public partial class WaterQualityIndicator : ControlledVocabularyBase
     {
         public WaterQualityIndicator()
         {
             WaterSourcesDim = new HashSet<WaterSourcesDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<WaterSourcesDim> WaterSourcesDim { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaterSourceType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaterSourceType.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class WaterSourceType
+    public partial class WaterSourceType : ControlledVocabularyBase
     {
         public WaterSourceType()
         {
             WaterSourcesDim = new HashSet<WaterSourcesDim>();
         }
-
-        public string Name { get; set; }
-        public string Term { get; set; }
-        public string Definition { get; set; }
-        public string State { get; set; }
-        public string SourceVocabularyUri { get; set; }
 
         public virtual ICollection<WaterSourcesDim> WaterSourcesDim { get; set; }
 

--- a/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiProfile.cs
@@ -94,7 +94,7 @@ namespace WesternStatesWater.WaDE.Accessors.Mapping
                 .ForMember(a => a.Term, b => b.MapFrom(c => c.BeneficialUse.Term))
                 .ForMember(a => a.State, b => b.MapFrom(c => c.BeneficialUse.State))
                 .ForMember(a => a.Definition, b => b.MapFrom(c => c.BeneficialUse.Definition))
-                .ForMember(a => a.SourceVocabularyURI, b => b.MapFrom(c => c.BeneficialUse.SourceVocabularyURI))
+                .ForMember(a => a.SourceVocabularyURI, b => b.MapFrom(c => c.BeneficialUse.SourceVocabularyUri))
                 .ForMember(a => a.Name, b => b.MapFrom(c => c.BeneficialUse.Name))
                 .ForMember(a => a.USGSCategory, b => b.MapFrom(c => c.BeneficialUse.UsgscategoryNameCv))
                 .ForMember(a => a.NAICSCode, b => b.MapFrom(c => c.BeneficialUse.NaicscodeNameCv));

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/CvNameGenerator.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/CvNameGenerator.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers;
+
+/// <summary>
+/// CV name generator.
+/// Each CV table has different column sizes. This class generates a unique name from A-Z, then AA-ZZ, ect.
+/// </summary>
+public static class CvNameGenerator
+{
+    /// <summary>
+    /// Creates a new unique name from A-Z, then AA-ZZ, ect.
+    /// </summary>
+    /// <param name="maxLength">The next name size cannot exceed max length.</param>
+    /// <returns>Unique Name used for CV Name column.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static string GetNextName(int index, int maxLength)
+    {
+        if (maxLength <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLength), "Max length must be greater than 0.");
+
+        const int alphabetLength = 26;
+        const char firstChar = 'A';
+        
+        var result = string.Empty;
+
+        while (index >= 0)
+        {
+            result = (char)(firstChar + (index % alphabetLength)) + result;
+
+            // Stop if adding another character exceeds maxLength
+            if (result.Length > maxLength)
+                throw new InvalidOperationException("Global index exceeded the maxLength limit.");
+
+            index = (index / alphabetLength) - 1;
+        }
+
+        return result;
+    }
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/FakerExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/FakerExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Bogus;
+﻿using System;
+using Bogus;
 using WesternStatesWater.WaDE.Utilities;
 
 namespace WesternStatesWater.WaDE.Tests.Helpers

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Api/BeneficialUseBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Api/BeneficialUseBuilder.cs
@@ -5,18 +5,25 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Api
 {
     public static class BeneficialUseBuilder
     {
+        private static int _globalIndex = 0;
         public static BeneficialUse Create()
         {
             var faker = new Faker<BeneficialUse>()
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
                 .RuleFor(a => a.Definition, f => f.Lorem.Sentence())
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.SourceVocabularyURI, f => f.Internet.Url())
                 .RuleFor(a => a.USGSCategory, f => f.Random.Word())
                 .RuleFor(a => a.NAICSCode, f => f.Random.Word());
 
             return faker;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,100);
         }
     }
 }

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Api/BeneficialUseBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Api/BeneficialUseBuilder.cs
@@ -11,7 +11,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Api
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
                 .RuleFor(a => a.Definition, f => f.Lorem.Sentence())
-                .RuleFor(a => a.Name, f => f.Random.Word())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.SourceVocabularyURI, f => f.Internet.Url())
                 .RuleFor(a => a.USGSCategory, f => f.Random.Word())
                 .RuleFor(a => a.NAICSCode, f => f.Random.Word());

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/AggregationStatisticBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/AggregationStatisticBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static AggregationStatistic Create(AggregationStatisticBuilderOptions opts)
         {
             return new Faker<AggregationStatistic>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/AggregationStatisticBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/AggregationStatisticBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class AggregationStatisticBuilder
     {
+        private static int _globalIndex = 0;
         public static AggregationStatistic Create()
         {
             return Create(new AggregationStatisticBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static AggregationStatistic Create(AggregationStatisticBuilderOptions opts)
         {
             return new Faker<AggregationStatistic>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ApplicableResourceTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ApplicableResourceTypeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class ApplicableResourceTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static ApplicableResourceType Create()
         {
             return Create(new ApplicableResourceTypeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static ApplicableResourceType Create(ApplicableResourceTypeBuilderOptions opts)
         {
             return new Faker<ApplicableResourceType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ApplicableResourceTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ApplicableResourceTypeBuilder.cs
@@ -14,16 +14,11 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static ApplicableResourceType Create(ApplicableResourceTypeBuilderOptions opts)
         {
             return new Faker<ApplicableResourceType>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
                 .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(100);
         }
 
         public static async Task<ApplicableResourceType> Load(WaDEContext db)

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/BeneficalUsesBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/BeneficalUsesBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class BeneficalUsesBuilder
     {
+        private static int _globalIndex = 0;
         public static BeneficialUsesCV Create()
         {
             return Create(new BeneficalUsesBuilderOptions());
@@ -14,11 +15,11 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static BeneficialUsesCV Create(BeneficalUsesBuilderOptions opts)
         {
             return new Faker<BeneficialUsesCV>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
-                .RuleFor(a => a.SourceVocabularyURI, f => f.Internet.Url());
+                .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
         }
 
         public static async Task<BeneficialUsesCV> Load(WaDEContext db)
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/BeneficalUsesBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/BeneficalUsesBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static BeneficialUsesCV Create(BeneficalUsesBuilderOptions opts)
         {
             return new Faker<BeneficialUsesCV>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CoordinateMethodBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CoordinateMethodBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class CoordinateMethodBuilder
     {
+        private static int _globalIndex = 0;
         public static CoordinateMethod Create()
         {
             return Create(new CoordinateMethodBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static CoordinateMethod Create(CoordinateMethodBuilderOptions opts)
         {
             var faker = new Faker<CoordinateMethod>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(2))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(10))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(10))
@@ -36,6 +37,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,100);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CoordinateMethodBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CoordinateMethodBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static CoordinateMethod Create(CoordinateMethodBuilderOptions opts)
         {
             var faker = new Faker<CoordinateMethod>()
-                .RuleFor(a => a.Name, f => f.Random.AlphaNumeric(100))
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(2))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(10))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(10))

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CropTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CropTypeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class CropTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static CropType Create()
         {
             return Create(new CropTypeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static CropType Create(CropTypeBuilderOptions opts)
         {
             return new Faker<CropType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CropTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CropTypeBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static CropType Create(CropTypeBuilderOptions opts)
         {
             return new Faker<CropType>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.Word();
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CustomerTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CustomerTypeBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static CustomerType Create(CustomerTypeBuilderOptions opts)
         {
             return new Faker<CustomerType>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.Word();
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CustomerTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/CustomerTypeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class CustomerTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static CustomerType Create()
         {
             return Create(new CustomerTypeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static CustomerType Create(CustomerTypeBuilderOptions opts)
         {
             return new Faker<CustomerType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,100);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/DataQualityValueBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/DataQualityValueBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static DataQualityValue Create(DataQualityValueBuilderOptions opts)
         {
             return new Faker<DataQualityValue>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/DataQualityValueBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/DataQualityValueBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class DataQualityValueBuilder
     {
+        private static int _globalIndex = 0;
         public static DataQualityValue Create()
         {
             return Create(new DataQualityValueBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static DataQualityValue Create(DataQualityValueBuilderOptions opts)
         {
             return new Faker<DataQualityValue>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/EpsgcodeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/EpsgcodeBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static Epsgcode Create(EpsgcodeBuilderOptions opts)
         {
             return new Faker<Epsgcode>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/EpsgcodeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/EpsgcodeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class EpsgcodeBuilder
     {
+        private static int _globalIndex = 0;
         public static Epsgcode Create()
         {
             return Create(new EpsgcodeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static Epsgcode Create(EpsgcodeBuilderOptions opts)
         {
             return new Faker<Epsgcode>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/GnisfeatureNameBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/GnisfeatureNameBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class GnisfeatureNameBuilder
     {
+        private static int _globalIndex = 0;
         public static GnisfeatureName Create()
         {
             return Create(new GnisfeatureNameBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static GnisfeatureName Create(GnisfeatureNameBuilderOptions opts)
         {
             var faker = new Faker<GnisfeatureName>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(250))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(4000))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))
@@ -36,6 +37,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/GnisfeatureNameBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/GnisfeatureNameBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static GnisfeatureName Create(GnisfeatureNameBuilderOptions opts)
         {
             var faker = new Faker<GnisfeatureName>()
-                .RuleFor(a => a.Name, f => f.Random.AlphaNumeric(50))
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(250))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(4000))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/IrrigationMethodBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/IrrigationMethodBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class IrrigationMethodBuilder
     {
+        private static int _globalIndex = 0;
         public static IrrigationMethod Create()
         {
             return Create(new IrrigationMethodBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static IrrigationMethod Create(IrrigationMethodBuilderOptions opts)
         {
             return new Faker<IrrigationMethod>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,100);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/IrrigationMethodBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/IrrigationMethodBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static IrrigationMethod Create(IrrigationMethodBuilderOptions opts)
         {
             return new Faker<IrrigationMethod>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.Word();
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/MethodTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/MethodTypeBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static MethodType Create(MethodTypeBuilderOptions opts)
         {
             return new Faker<MethodType>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/MethodTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/MethodTypeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class MethodTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static MethodType Create()
         {
             return Create(new MethodTypeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static MethodType Create(MethodTypeBuilderOptions opts)
         {
             return new Faker<MethodType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/MethodsDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/MethodsDimBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class MethodsDimBuilder
     {
+        private static int _globalIndex = 0;
         public static MethodsDim Create()
         {
             return Create(new MethodsDimBuilderOptions());
@@ -19,7 +20,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.MethodDescription, f => f.Random.Words(5))
                 .RuleFor(a => a.MethodNemilink, f => f.Internet.Url())
                 .RuleFor(a => a.ApplicableResourceTypeCv, f => opts.ApplicableResourceType?.Name ?? ApplicableResourceTypeBuilder.GenerateName())
-                .RuleFor(a => a.MethodTypeCv, f => opts.MethodType?.Name ?? MethodTypeBuilder.GenerateName())
+                .RuleFor(a => a.MethodTypeCv, f => opts.MethodType?.Name ?? f.Random.Word())
                 .RuleFor(a => a.DataCoverageValue, f => f.Random.Word())
                 .RuleFor(a => a.DataQualityValueCv, f => opts.DataQualityValue?.Name)
                 .RuleFor(a => a.DataConfidenceValue, f => f.Random.Word(50))

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/MethodsDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/MethodsDimBuilder.cs
@@ -20,7 +20,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.MethodDescription, f => f.Random.Words(5))
                 .RuleFor(a => a.MethodNemilink, f => f.Internet.Url())
                 .RuleFor(a => a.ApplicableResourceTypeCv, f => opts.ApplicableResourceType?.Name ?? ApplicableResourceTypeBuilder.GenerateName())
-                .RuleFor(a => a.MethodTypeCv, f => opts.MethodType?.Name ?? f.Random.Word())
+                .RuleFor(a => a.MethodTypeCv, f => opts.MethodType?.Name ?? MethodTypeBuilder.GenerateName())
                 .RuleFor(a => a.DataCoverageValue, f => f.Random.Word())
                 .RuleFor(a => a.DataQualityValueCv, f => opts.DataQualityValue?.Name)
                 .RuleFor(a => a.DataConfidenceValue, f => f.Random.Word(50))

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/NhdnetworkStatusBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/NhdnetworkStatusBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class NhdnetworkStatusBuilder
     {
+        private static int _globalIndex = 0;
         public static NhdnetworkStatus Create()
         {
             return Create(new NhdnetworkStatusBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static NhdnetworkStatus Create(NhdnetworkStatusBuilderOptions opts)
         {
             var faker = new Faker<NhdnetworkStatus>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(250))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(4000))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))
@@ -36,6 +37,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/NhdnetworkStatusBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/NhdnetworkStatusBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static NhdnetworkStatus Create(NhdnetworkStatusBuilderOptions opts)
         {
             var faker = new Faker<NhdnetworkStatus>()
-                .RuleFor(a => a.Name, f => f.Random.AlphaNumeric(50))
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(250))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(4000))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/NhdproductBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/NhdproductBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static Nhdproduct Create(NhdproductBuilderOptions opts)
         {
             var faker = new Faker<Nhdproduct>()
-                .RuleFor(a => a.Name, f => f.Random.AlphaNumeric(50))
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(250))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(4000))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/NhdproductBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/NhdproductBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class NhdproductBuilder
     {
+        private static int _globalIndex = 0;
         public static Nhdproduct Create()
         {
             return Create(new NhdproductBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static Nhdproduct Create(NhdproductBuilderOptions opts)
         {
             var faker = new Faker<Nhdproduct>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(250))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(4000))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))
@@ -36,6 +37,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OwnerClassificationBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OwnerClassificationBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static OwnerClassificationCv Create(OwnerClassificationBuilderOptions opts)
         {
             return new Faker<OwnerClassificationCv>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OwnerClassificationBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OwnerClassificationBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class OwnerClassificationBuilder
     {
+        private static int _globalIndex = 0;
         public static OwnerClassificationCv Create()
         {
             return Create(new OwnerClassificationBuilderOptions());
@@ -14,11 +15,11 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static OwnerClassificationCv Create(OwnerClassificationBuilderOptions opts)
         {
             return new Faker<OwnerClassificationCv>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
-                .RuleFor(a => a.SourceVocabularyURI, f => f.Internet.Url());
+                .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
         }
 
         public static async Task<OwnerClassificationCv> Load(WaDEContext db)
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/PowerTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/PowerTypeBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static PowerType Create(PowerTypeBuilderOptions opts)
         {
             return new Faker<PowerType>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/PowerTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/PowerTypeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class PowerTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static PowerType Create()
         {
             return Create(new PowerTypeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static PowerType Create(PowerTypeBuilderOptions opts)
         {
             return new Faker<PowerType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -38,7 +39,8 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 
         public static string GenerateName()
         {
-            return new Faker().Random.Word();
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayDimBuilder.cs
@@ -18,14 +18,14 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.RegulatoryOverlayNativeId, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.RegulatoryName, f => f.Company.CompanyName())
                 .RuleFor(a => a.RegulatoryDescription, f => f.Rant.ToString())
-                .RuleFor(a => a.RegulatoryStatusCv, f => opts?.RegulatoryStatus?.Name ?? f.Random.Word(50))
+                .RuleFor(a => a.RegulatoryStatusCv, f => opts?.RegulatoryStatus?.Name ?? RegulatoryStatusBuilder.GenerateName())
                 .RuleFor(a => a.OversightAgency, f => f.Company.CompanyName())
                 .RuleFor(a => a.RegulatoryStatute, f => f.Random.Word())
                 .RuleFor(a => a.RegulatoryStatuteLink, f => f.Internet.Url())
                 .RuleFor(a => a.StatutoryEffectiveDate, f => f.Date.Past(10))
                 .RuleFor(a => a.StatutoryEndDate, f => f.Date.Past(5))
-                .RuleFor(a => a.RegulatoryOverlayTypeCV, f => opts?.RegulatoryOverlayType?.Name ?? f.Random.AlphaNumeric(10))
-                .RuleFor(a => a.WaterSourceTypeCV, f => opts?.WaterSourceType?.Name ?? f.Random.AlphaNumeric(10));
+                .RuleFor(a => a.RegulatoryOverlayTypeCV, f => opts?.RegulatoryOverlayType?.Name ?? RegulatoryOverlayTypeBuilder.GenerateName())
+                .RuleFor(a => a.WaterSourceTypeCV, f => opts?.WaterSourceType?.Name ?? WaterSourceTypeBuilder.GenerateName());
         }
 
         public static async Task<RegulatoryOverlayDim> Load(WaDEContext db)

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayTypeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class RegulatoryOverlayTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static RegulatoryOverlayType Create()
         {
             return Create(new RegulatoryOverlayTypeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static RegulatoryOverlayType Create(RegulatoryOverlayTypeBuilderOptions opts)
         {
             return new Faker<RegulatoryOverlayType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,100);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayTypeBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static RegulatoryOverlayType Create(RegulatoryOverlayTypeBuilderOptions opts)
         {
             return new Faker<RegulatoryOverlayType>()
-                .RuleFor(a => a.Name, f => f.Random.Word())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -35,15 +35,9 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 
             return item;
         }
-
-        public static long GenerateId()
-        {
-            return new Faker().Random.Long(1);
-        }
     }
 
     public class RegulatoryOverlayTypeBuilderOptions
     {
-        
     }
 }

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryStatusBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryStatusBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class RegulatoryStatusBuilder
     {
+        private static int _globalIndex = 0;
         public static RegulatoryStatus Create()
         {
             return Create(new RegulatoryStatusBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static RegulatoryStatus Create(RegulatoryStatusBuilderOptions opts)
         {
             return new Faker<RegulatoryStatus>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -36,9 +37,10 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             return item;
         }
 
-        public static long GenerateId()
+        public static string GenerateName()
         {
-            return new Faker().Random.Long(1);
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryStatusBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryStatusBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static RegulatoryStatus Create(RegulatoryStatusBuilderOptions opts)
         {
             return new Faker<RegulatoryStatus>()
-                .RuleFor(a => a.Name, f => f.Random.Word())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportYearTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportYearTypeBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static ReportYearType Create(ReportYearTypeBuilderOptions opts)
         {
             return new Faker<ReportYearType>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportYearTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportYearTypeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class ReportYearTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static ReportYearType Create()
         {
             return Create(new ReportYearTypeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static ReportYearType Create(ReportYearTypeBuilderOptions opts)
         {
             return new Faker<ReportYearType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportingUnitTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportingUnitTypeBuilder.cs
@@ -15,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static ReportingUnitType Create(ReportingUnitTypeBuilderOptions opts)
         {
             return new Faker<ReportingUnitType>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -41,16 +41,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             }
 
             return matching;
-        }
-
-        public static string GenerateName()
-        {
-            string name;
-            do
-            {
-                name = new Faker().Random.Word();
-            } while (name.Length > 50);
-            return name;
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportingUnitTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportingUnitTypeBuilder.cs
@@ -7,6 +7,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class ReportingUnitTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static ReportingUnitType Create()
         {
             return Create(new ReportingUnitTypeBuilderOptions());
@@ -15,7 +16,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static ReportingUnitType Create(ReportingUnitTypeBuilderOptions opts)
         {
             return new Faker<ReportingUnitType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -41,6 +42,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             }
 
             return matching;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,50);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportingUnitsDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/ReportingUnitsDimBuilder.cs
@@ -18,7 +18,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.ReportingUnitUuid, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.ReportingUnitNativeId, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.ReportingUnitName, f => f.Company.CompanyName())
-                .RuleFor(a => a.ReportingUnitTypeCv, f => opts.ReportingUnitType?.Name ?? f.Random.Word())
+                .RuleFor(a => a.ReportingUnitTypeCv, f => opts.ReportingUnitType?.Name ?? ReportingUnitTypeBuilder.GenerateName())
                 .RuleFor(a => a.ReportingUnitUpdateDate, f => f.Date.Past())
                 .RuleFor(a => a.ReportingUnitProductVersion, f => f.System.Version().ToString())
                 .RuleFor(a => a.StateCv, f => opts.State?.Name ?? f.Address.StateAbbr())

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SDWISIdentifierBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SDWISIdentifierBuilder.cs
@@ -1,9 +1,11 @@
 ﻿using Bogus;
 using System.Threading.Tasks;
 using WesternStatesWater.WaDE.Accessors.EntityFramework;
+using WesternStatesWater.WaDE.Tests.Helpers;
 
 public static class SDWISIdentifierBuilder
 {
+    private static int _globalIndex = 0;
     public static SDWISIdentifier Create()
     {
         return Create(new SDWISIdentifierBuilderOptions());
@@ -12,7 +14,7 @@ public static class SDWISIdentifierBuilder
     public static SDWISIdentifier Create(SDWISIdentifierBuilderOptions opts)
     {
         return new Faker<SDWISIdentifier>()
-            .RuleFor(a => a.Name, f => f.Date.Past(5).Year.ToString())
+            .RuleFor(a => a.Name, f => GenerateName())
             .RuleFor(a => a.Term, f => f.Random.Word())
             .RuleFor(a => a.Definition, f => f.Random.Words(5))
             .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,9 +36,10 @@ public static class SDWISIdentifierBuilder
         return item;
     }
 
-    public static long GenerateId()
+    public static string GenerateName()
     {
-        return new Faker().Random.Long(1);
+        _globalIndex++;
+        return CvNameGenerator.GetNextName(_globalIndex,100);
     }
 }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SiteTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SiteTypeBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static SiteType Create(SiteTypeBuilderOptions opts)
         {
             var faker = new Faker<SiteType>()
-                .RuleFor(a => a.Name, f => f.Random.AlphaNumeric(100))
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(250))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(40))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SiteTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/SiteTypeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class SiteTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static SiteType Create()
         {
             return Create(new SiteTypeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static SiteType Create(SiteTypeBuilderOptions opts)
         {
             var faker = new Faker<SiteType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(250))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(40))
                 .RuleFor(a => a.State, f => f.Random.AlphaNumeric(250))
@@ -36,6 +37,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,100);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/StateBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/StateBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static State Create(StateBuilderOptions opts)
         {
             return new Faker<State>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(2))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(10))
                 .RuleFor(a => a.State1, f => f.Random.AlphaNumeric(10))
@@ -37,11 +37,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Address.StateAbbr();
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/StateBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/StateBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class StateBuilder
     {
+        private static int _globalIndex = 0;
         public static State Create()
         {
             return Create(new StateBuilderOptions());
@@ -14,10 +15,10 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static State Create(StateBuilderOptions opts)
         {
             return new Faker<State>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.AlphaNumeric(2))
                 .RuleFor(a => a.Definition, f => f.Random.AlphaNumeric(10))
-                .RuleFor(a => a.State1, f => f.Random.AlphaNumeric(10))
+                .RuleFor(a => a.State, f => f.Random.AlphaNumeric(10))
                 .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
         }
 
@@ -37,6 +38,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,2);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/UnitsBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/UnitsBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static Units Create(UnitsBuilderOptions opts)
         {
             return new Faker<Units>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/UnitsBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/UnitsBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class UnitsBuilder
     {
+        private static int _globalIndex = 0;
         public static Units Create()
         {
             return Create(new UnitsBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static Units Create(UnitsBuilderOptions opts)
         {
             return new Faker<Units>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static Variable Create(VariableBuilderOptions opts)
         {
             return new Faker<Variable>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class VariableBuilder
     {
+        private static int _globalIndex = 0;
         public static Variable Create()
         {
             return Create(new VariableBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static Variable Create(VariableBuilderOptions opts)
         {
             return new Faker<Variable>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableSpecificBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableSpecificBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class VariableSpecificBuilder
     {
+        private static int _globalIndex = 0;
         public static VariableSpecific Create()
         {
             return Create(new VariableSpecificBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static VariableSpecific Create(VariableSpecificBuilderOptions opts)
         {
             return new Faker<VariableSpecific>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableSpecificBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableSpecificBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static VariableSpecific Create(VariableSpecificBuilderOptions opts)
         {
             return new Faker<VariableSpecific>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(250);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariablesDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariablesDimBuilder.cs
@@ -15,14 +15,14 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         {
             return new Faker<VariablesDim>()
                 .RuleFor(a => a.VariableSpecificUuid, f => f.Random.Uuid().ToString())
-                .RuleFor(a => a.VariableSpecificCv, f => opts.VariableSpecific?.Name ?? VariableSpecificBuilder.GenerateName())
-                .RuleFor(a => a.VariableCv, f => opts.Variable?.Name ?? VariableBuilder.GenerateName())
-                .RuleFor(a => a.AggregationStatisticCv, f => opts.AggregationStatistic?.Name ?? AggregationStatisticBuilder.GenerateName())
+                .RuleFor(a => a.VariableSpecificCv, f => opts.VariableSpecific?.Name ?? f.Random.Word())
+                .RuleFor(a => a.VariableCv, f => opts.Variable?.Name ?? f.Random.Word())
+                .RuleFor(a => a.AggregationStatisticCv, f => opts.AggregationStatistic?.Name ?? f.Random.Word())
                 .RuleFor(a => a.AggregationInterval, f => f.Random.Decimal(1, 300))
-                .RuleFor(a => a.AggregationIntervalUnitCv, f => opts.AggregationIntervalUnit?.Name ?? UnitsBuilder.GenerateName())
+                .RuleFor(a => a.AggregationIntervalUnitCv, f => opts.AggregationIntervalUnit?.Name ?? f.Random.Word())
                 .RuleFor(a => a.ReportYearStartMonth, f => f.Date.Month())
-                .RuleFor(a => a.ReportYearTypeCv, f => opts.ReportYearType?.Name ?? ReportYearTypeBuilder.GenerateName())
-                .RuleFor(a => a.AmountUnitCv, f => opts.AmountUnit?.Name ?? UnitsBuilder.GenerateName())
+                .RuleFor(a => a.ReportYearTypeCv, f => opts.ReportYearType?.Name ?? f.Random.Word())
+                .RuleFor(a => a.AmountUnitCv, f => opts.AmountUnit?.Name ?? f.Random.Word())
                 .RuleFor(a => a.MaximumAmountUnitCv, f => opts.MaximumAmountUnit?.Name);
         }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterQualityIndicatorBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterQualityIndicatorBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class WaterQualityIndicatorBuilder
     {
+        private static int _globalIndex = 0;
         public static WaterQualityIndicator Create()
         {
             return Create(new WaterQualityIndicatorBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static WaterQualityIndicator Create(WaterQualityIndicatorBuilderOptions opts)
         {
             return new Faker<WaterQualityIndicator>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,100);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterQualityIndicatorBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterQualityIndicatorBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static WaterQualityIndicator Create(WaterQualityIndicatorBuilderOptions opts)
         {
             return new Faker<WaterQualityIndicator>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(100);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterSourceTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterSourceTypeBuilder.cs
@@ -14,7 +14,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static WaterSourceType Create(WaterSourceTypeBuilderOptions opts)
         {
             return new Faker<WaterSourceType>()
-                .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,11 +34,6 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
-        }
-
-        public static string GenerateName()
-        {
-            return new Faker().Random.AlphaNumeric(100);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterSourceTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterSourceTypeBuilder.cs
@@ -6,6 +6,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
     public static class WaterSourceTypeBuilder
     {
+        private static int _globalIndex = 0;
         public static WaterSourceType Create()
         {
             return Create(new WaterSourceTypeBuilderOptions());
@@ -14,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static WaterSourceType Create(WaterSourceTypeBuilderOptions opts)
         {
             return new Faker<WaterSourceType>()
-                .RuleFor(a => a.Name, f => f.Random.Uuid().ToString())
+                .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -34,6 +35,12 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
             await db.SaveChangesAsync();
 
             return item;
+        }
+        
+        public static string GenerateName()
+        {
+            _globalIndex++;
+            return CvNameGenerator.GetNextName(_globalIndex,100);
         }
     }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterSourcesDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterSourcesDimBuilder.cs
@@ -18,7 +18,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.WaterSourceNativeId, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.WaterSourceName, f => f.Random.Word())
                 .RuleFor(a => a.WaterSourceTypeCv, f => opts.WaterSourceType?.Name ?? f.Random.Word())
-                .RuleFor(a => a.WaterQualityIndicatorCv, f => opts.WaterQualityIndicator?.Name ?? f.Random.Word())
+                .RuleFor(a => a.WaterQualityIndicatorCv, f => opts.WaterQualityIndicator?.Name ?? WaterQualityIndicatorBuilder.GenerateName())
                 .RuleFor(a => a.GnisfeatureNameCv, f => opts.GnisfeatureName?.Name);
         }
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterSourcesDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/WaterSourcesDimBuilder.cs
@@ -17,8 +17,8 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.WaterSourceUuid, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.WaterSourceNativeId, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.WaterSourceName, f => f.Random.Word())
-                .RuleFor(a => a.WaterSourceTypeCv, f => opts.WaterSourceType?.Name ?? WaterSourceTypeBuilder.GenerateName())
-                .RuleFor(a => a.WaterQualityIndicatorCv, f => opts.WaterQualityIndicator?.Name ?? WaterQualityIndicatorBuilder.GenerateName())
+                .RuleFor(a => a.WaterSourceTypeCv, f => opts.WaterSourceType?.Name ?? f.Random.Word())
+                .RuleFor(a => a.WaterQualityIndicatorCv, f => opts.WaterQualityIndicator?.Name ?? f.Random.Word())
                 .RuleFor(a => a.GnisfeatureNameCv, f => opts.GnisfeatureName?.Name);
         }
 


### PR DESCRIPTION
# Issue
CV Tables would more often then not throw a change tracking error. This was caused by Bogous Random.Word() being duplicated.

# Solution
This solution I built a CvNameGenerate class. This method can generate a unique CV name by incrementing the index. It currently just goes from A-Z, then rolls over to AA, AB, AC, etc. Max length is the CV Name column size so you can restrict building a name that's too large for the database. Each faker builder manages it's own index so we don't cause issues between CV tables.

I also consolidated all the duplicate columns between all the CV tables into a ControlledVocabularyBase. Hopefully this makes new tables quicker to implement. 