### PR TITLE
Update OverlaySearchHandler Return Areas

### DIFF
--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/IRegulatoryOverlayAccessor.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/IRegulatoryOverlayAccessor.cs
@@ -1,4 +1,6 @@
 ﻿using System.Threading.Tasks;
+using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Requests;
+using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Responses;
 
 namespace WesternStatesWater.WaDE.Accessors.Contracts.Api
 {
@@ -8,5 +10,9 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Api
             int startIndex, int recordCount);
 
         Task<OverlayMetadata> GetOverlayMetadata();
+        
+        public Task<TResponse> Search<TRequest, TResponse>(TRequest request)
+            where TRequest : SearchRequestBase
+            where TResponse : SearchResponseBase;
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
@@ -16,8 +16,8 @@ public class OverlaySearchItem
     public string StatutoryEndDate { get; set; }
     public string OverlayType { get; set; }
     public string WaterSource { get; set; }
-    public string AreaName { get; set; }
-    public string AreaNativeId { get; set; }
-    public string SiteUuids { get; set; }
+    public string[] AreaName { get; set; }
+    public string[] AreaNativeId { get; set; }
+    public string[] SiteUuids { get; set; }
     public Geometry Areas { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
@@ -16,8 +16,8 @@ public class OverlaySearchItem
     public string StatutoryEndDate { get; set; }
     public string OverlayType { get; set; }
     public string WaterSource { get; set; }
-    public string[] AreaName { get; set; }
-    public string[] AreaNativeId { get; set; }
+    public string[] AreaNames { get; set; }
+    public string[] AreaNativeIds { get; set; }
     public string[] SiteUuids { get; set; }
     public Geometry Areas { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
@@ -1,3 +1,5 @@
+using NetTopologySuite.Geometries;
+
 namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2;
 
 public class OverlaySearchItem
@@ -17,4 +19,5 @@ public class OverlaySearchItem
     public string AreaName { get; set; }
     public string AreaNativeId { get; set; }
     public string SiteUuids { get; set; }
+    public Geometry Areas { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/OverlaySearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/OverlaySearchRequest.cs
@@ -7,6 +7,6 @@ public class OverlaySearchRequest : SearchRequestBase
 {
     public List<string> OverlayUuids { get; set; }
     public List<string> SiteUuids { get; set; }
-    public Polygon FilterBoundary { get; set; }
+    public Geometry FilterBoundary { get; set; }
     public string LastKey { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/ApiRegulatoryOverlayAccessorTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/ApiRegulatoryOverlayAccessorTests.cs
@@ -4,8 +4,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Telerik.JustMock;
 using WesternStatesWater.WaDE.Accessors.Contracts.Api;
 using WesternStatesWater.WaDE.Accessors.EntityFramework;
+using WesternStatesWater.WaDE.Accessors.Handlers;
 using WesternStatesWater.WaDE.Tests.Helpers;
 using WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework;
 
@@ -131,7 +133,10 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
 
         private IRegulatoryOverlayAccessor CreateRegulatoryOverlayAccessor()
         {
-            return new RegulatoryOverlayAccessor(Configuration.GetConfiguration(), LoggerFactory);
+            return new RegulatoryOverlayAccessor(
+                Configuration.GetConfiguration(), 
+                LoggerFactory,
+                Mock.Create<IAccessorRequestHandlerResolver>());
         }
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
@@ -140,7 +140,7 @@ public class OverlaySearchHandlerTests : DbTestBase
 
         var areaOutsideRequest = await ReportingUnitsDimBuilder.Load(db, new ReportingUnitsDimBuilderOptions
         {
-            Geometry = createVegasyGeometry()
+            Geometry = CreateVegasyGeometry()
         });
 
         var areaInersectingRequest = await ReportingUnitsDimBuilder.Load(db, new ReportingUnitsDimBuilderOptions
@@ -150,7 +150,7 @@ public class OverlaySearchHandlerTests : DbTestBase
 
         var areaInsideRequest = await ReportingUnitsDimBuilder.Load(db, new ReportingUnitsDimBuilderOptions
         {
-            Geometry = createGreatSaltLakeGeometry()
+            Geometry = CreateGreatSaltLakeGeometry()
         });
 
         var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
@@ -162,13 +162,13 @@ public class OverlaySearchHandlerTests : DbTestBase
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaInersectingRequest
         });
-        
+
         await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayB,
             ReportingUnits = areaInsideRequest
         });
-        
+
         await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = omittedOverlay,
@@ -194,9 +194,9 @@ public class OverlaySearchHandlerTests : DbTestBase
     public async Task Handler_OverlaysWithIntersectingAreas_CombinedIntoASingleGeometryPolygon()
     {
         await using var db = new WaDEContext(Configuration.GetConfiguration());
-        
+
         var wkt = new NetTopologySuite.IO.WKTReader();
-        
+
         // Create Intersecting Polygons
         var polygonA = (Polygon) wkt.Read(
             "POLYGON ((-105.394592 39.7093, -105.174866 39.7093, -105.174866 39.907629, -105.394592 39.907629, -105.394592 39.7093))");
@@ -216,32 +216,32 @@ public class OverlaySearchHandlerTests : DbTestBase
         {
             Geometry = polygonB
         });
-        
+
         var areaC = await ReportingUnitsDimBuilder.Load(db, new ReportingUnitsDimBuilderOptions
         {
             Geometry = polygonC
         });
 
         var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        
+
         await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaA
         });
-        
+
         await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaB
         });
-        
+
         await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaC
         });
-        
+
         var request = new OverlaySearchRequest
         {
             Limit = 5
@@ -259,9 +259,9 @@ public class OverlaySearchHandlerTests : DbTestBase
     public async Task Handler_OverlaysWithNonIntersectingAreas_CombinedIntoASingleGeometryMultiPolygon()
     {
         await using var db = new WaDEContext(Configuration.GetConfiguration());
-        
+
         var wkt = new NetTopologySuite.IO.WKTReader();
-        
+
         // Create Non-Intersecting Polygons
         var polygonA = (Polygon) wkt.Read(
             "POLYGON ((-106.929932 43.452919, -106.358643 43.452919, -106.358643 43.771094, -106.929932 43.771094, -106.929932 43.452919))");
@@ -281,27 +281,27 @@ public class OverlaySearchHandlerTests : DbTestBase
         {
             Geometry = polygonB
         });
-        
+
         var areaC = await ReportingUnitsDimBuilder.Load(db, new ReportingUnitsDimBuilderOptions
         {
             Geometry = polygonC
         });
-        
+
         var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        
-        
+
+
         await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaA
         });
-        
+
         await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaB
         });
-        
+
         await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
@@ -319,6 +319,117 @@ public class OverlaySearchHandlerTests : DbTestBase
         // Assert
         response.Overlays.Should().HaveCount(1);
         response.Overlays[0].Areas.Should().BeOfType<MultiPolygon>();
+    }
+
+    [TestMethod]
+    public async Task Handler_OverlayWithManyAreas_ReturnsRelatedAreaInformation()
+    {
+        await using var db = new WaDEContext(Configuration.GetConfiguration());
+
+        var wkt = new NetTopologySuite.IO.WKTReader();
+
+        var polygonA = (Polygon) wkt.Read(
+            "POLYGON ((-106.929932 43.452919, -106.358643 43.452919, -106.358643 43.771094, -106.929932 43.771094, -106.929932 43.452919))");
+        var polygonB =
+            (Polygon) wkt.Read(
+                "POLYGON ((-106.11969 43.548548, -105.970001 43.548548, -105.970001 43.674825, -106.11969 43.674825, -106.11969 43.548548))");
+        var polygonC =
+            (Polygon) wkt.Read(
+                "POLYGON ((-107.381744 43.569447, -107.124939 43.569447, -107.124939 43.658931, -107.381744 43.658931, -107.381744 43.569447))");
+
+        var areaA = await ReportingUnitsDimBuilder.Load(db, new ReportingUnitsDimBuilderOptions
+        {
+            Geometry = polygonA
+        });
+
+        var areaB = await ReportingUnitsDimBuilder.Load(db, new ReportingUnitsDimBuilderOptions
+        {
+            Geometry = polygonB
+        });
+
+        var areaC = await ReportingUnitsDimBuilder.Load(db, new ReportingUnitsDimBuilderOptions
+        {
+            Geometry = polygonC
+        });
+
+        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
+
+
+        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        {
+            RegulatoryOverlay = overlayA,
+            ReportingUnits = areaA
+        });
+
+        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        {
+            RegulatoryOverlay = overlayA,
+            ReportingUnits = areaB
+        });
+
+        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        {
+            RegulatoryOverlay = overlayA,
+            ReportingUnits = areaC
+        });
+
+        var request = new OverlaySearchRequest
+        {
+            Limit = 5
+        };
+
+        // Act
+        var response = await ExecuteHandler(request);
+
+        // Assert
+        response.Overlays.Should().HaveCount(1);
+        response.Overlays[0].AreaName.Should().BeEquivalentTo(
+            areaA.ReportingUnitName, areaB.ReportingUnitName, areaC.ReportingUnitName);
+        response.Overlays[0].AreaNativeId.Should().BeEquivalentTo(
+            areaA.ReportingUnitNativeId, areaB.ReportingUnitNativeId, areaC.ReportingUnitNativeId);
+    }
+
+    [TestMethod]
+    public async Task Handler_OverlayWithManySites_ReturnsSiteUuids()
+    {
+        await using var db = new WaDEContext(Configuration.GetConfiguration());
+
+        var siteA = await SitesDimBuilder.Load(db);
+        var siteB = await SitesDimBuilder.Load(db);
+        var siteC = await SitesDimBuilder.Load(db);
+
+        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
+
+        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
+        {
+            SitesDim = siteA,
+            RegulatoryOverlayDim = overlayA
+        });
+
+        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
+        {
+            SitesDim = siteB,
+            RegulatoryOverlayDim = overlayA
+        });
+
+        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
+        {
+            SitesDim = siteC,
+            RegulatoryOverlayDim = overlayA
+        });
+
+        var request = new OverlaySearchRequest
+        {
+            Limit = 5
+        };
+
+        // Act
+        var response = await ExecuteHandler(request);
+
+        // Assert
+        response.Overlays.Should().HaveCount(1);
+        response.Overlays[0].SiteUuids.Should().BeEquivalentTo(
+            siteA.SiteUuid, siteB.SiteUuid, siteC.SiteUuid);
     }
 
     private async Task<OverlaySearchResponse> ExecuteHandler(OverlaySearchRequest request)
@@ -342,7 +453,7 @@ public class OverlaySearchHandlerTests : DbTestBase
     /// https://wktmap.com/?2abc3c2b
     /// </summary>
     /// <returns>Polygon around Great Salt Lake in Utah.</returns>
-    private static Geometry createGreatSaltLakeGeometry()
+    private static Geometry CreateGreatSaltLakeGeometry()
     {
         var wkt = new NetTopologySuite.IO.WKTReader();
         return wkt.Read(
@@ -364,7 +475,7 @@ public class OverlaySearchHandlerTests : DbTestBase
     /// https://wktmap.com/?31a14eec
     /// </summary>
     /// <returns>Polygon around Last Vegas, NV.</returns>
-    private static Geometry createVegasyGeometry()
+    private static Geometry CreateVegasyGeometry()
     {
         var wkt = new NetTopologySuite.IO.WKTReader();
         return wkt.Read(

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
@@ -383,9 +383,9 @@ public class OverlaySearchHandlerTests : DbTestBase
 
         // Assert
         response.Overlays.Should().HaveCount(1);
-        response.Overlays[0].AreaName.Should().BeEquivalentTo(
+        response.Overlays[0].AreaNames.Should().BeEquivalentTo(
             areaA.ReportingUnitName, areaB.ReportingUnitName, areaC.ReportingUnitName);
-        response.Overlays[0].AreaNativeId.Should().BeEquivalentTo(
+        response.Overlays[0].AreaNativeIds.Should().BeEquivalentTo(
             areaA.ReportingUnitNativeId, areaB.ReportingUnitNativeId, areaC.ReportingUnitNativeId);
     }
 

--- a/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using AutoMapper;
+using NetTopologySuite.Operation.Union;
 using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2;
 using EF = WesternStatesWater.WaDE.Accessors.EntityFramework;
 
@@ -57,7 +58,9 @@ public class ApiV2Profile : Profile
                     b => b.MapFrom(c =>
                         c.RegulatoryReportingUnitsFact.Select(fact => fact.ReportingUnit.ReportingUnitNativeId)))
                 .ForMember(a => a.SiteUuids,
-                    b => b.MapFrom(c => c.RegulatoryOverlayBridgeSitesFact.Select(fact => fact.Site.SiteUuid)));
+                    b => b.MapFrom(c => c.RegulatoryOverlayBridgeSitesFact.Select(fact => fact.Site.SiteUuid)))
+                .ForMember(a => a.Areas,
+                    b => b.MapFrom(c => UnaryUnionOp.Union(c.RegulatoryReportingUnitsFact.Select(fact => fact.ReportingUnit.Geometry))));
 
             CreateMap<EF.AllocationAmountsFact, AllocationSearchItem>()
                 .ForMember(a => a.AllocationApplicationDate,

--- a/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
@@ -51,10 +51,10 @@ public class ApiV2Profile : Profile
                 .ForMember(a => a.StatutoryEndDate, b => b.MapFrom(c => c.StatutoryEndDate))
                 .ForMember(a => a.OverlayType, b => b.MapFrom(c => c.RegulatoryOverlayTypeCV))
                 .ForMember(a => a.WaterSource, b => b.MapFrom(c => c.WaterSourceTypeCV))
-                .ForMember(a => a.AreaName,
+                .ForMember(a => a.AreaNames,
                     b => b.MapFrom(c =>
                         c.RegulatoryReportingUnitsFact.Select(fact => fact.ReportingUnit.ReportingUnitName)))
-                .ForMember(a => a.AreaNativeId,
+                .ForMember(a => a.AreaNativeIds,
                     b => b.MapFrom(c =>
                         c.RegulatoryReportingUnitsFact.Select(fact => fact.ReportingUnit.ReportingUnitNativeId)))
                 .ForMember(a => a.SiteUuids,


### PR DESCRIPTION
* Updated OverlaySearchItem to include Areas `Geometry`. Uses [UnaryUnionOp](https://nettopologysuite.github.io/NetTopologySuite/api/NetTopologySuite.Operation.Union.UnaryUnionOp.html).
* Fixed AreasName, AreasNativeIds, SiteUuids to be arrays