### PR TITLE
OGC formatting unit/reflection tests

### DIFF
--- a/source/WesternStatesWater.WaDE.Engines.Contracts/Attributes/FeaturePropertyNameAttribute.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/Attributes/FeaturePropertyNameAttribute.cs
@@ -1,5 +1,10 @@
 namespace WesternStatesWater.WaDE.Engines.Contracts.Attributes;
 
+/// <summary>
+/// Used to mark a property with the name of the property to be serialized in the GeoJson "properties" object.
+/// </summary>
+/// <param name="name"></param>
+[AttributeUsage(AttributeTargets.Property)]
 public class FeaturePropertyNameAttribute(string name) : Attribute
 {
     public string GetName() => name;

--- a/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Requests/FeaturesFormattingRequestBase.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Requests/FeaturesFormattingRequestBase.cs
@@ -1,0 +1,8 @@
+namespace WesternStatesWater.WaDE.Engines.Contracts.Ogc.Requests;
+
+public abstract class FeaturesFormattingRequestBase : FormattingRequestBase
+{
+    public required string CollectionId { get; init; }
+    public required FeatureBase[] Items { get; init; }
+    public string? LastUuid { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Requests/FeaturesRequest.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Requests/FeaturesRequest.cs
@@ -1,3 +1,0 @@
-namespace WesternStatesWater.WaDE.Engines.Contracts.Ogc.Requests;
-
-public class FeaturesRequest : FeaturesRequestBase;

--- a/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Requests/FeaturesRequestBase.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Requests/FeaturesRequestBase.cs
@@ -1,7 +1,0 @@
-namespace WesternStatesWater.WaDE.Engines.Contracts.Ogc.Requests;
-
-public abstract class FeaturesRequestBase : FormattingRequestBase
-{
-    public FeatureBase[] Items { get; set; }
-    public string? LastUuid { get; set; }
-}

--- a/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Requests/OgcFeaturesFormattingRequest.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Requests/OgcFeaturesFormattingRequest.cs
@@ -1,0 +1,3 @@
+namespace WesternStatesWater.WaDE.Engines.Contracts.Ogc.Requests;
+
+public class OgcFeaturesFormattingRequest : FeaturesFormattingRequestBase;

--- a/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Responses/OgcFeaturesFormattingResponse.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/Ogc/Responses/OgcFeaturesFormattingResponse.cs
@@ -1,3 +1,3 @@
 namespace WesternStatesWater.WaDE.Engines.Contracts.Ogc.Responses;
 
-public class FeaturesResponse : FeaturesResponseBase;
+public class OgcFeaturesFormattingResponse : FeaturesResponseBase;

--- a/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcFeaturesFormattingHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcFeaturesFormattingHandlerTests.cs
@@ -2,12 +2,13 @@ using System.Reflection;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NetTopologySuite.Geometries;
+using WesternStatesWater.WaDE.Contracts.Api.OgcApi;
 using WesternStatesWater.WaDE.Engines.Contracts;
 using WesternStatesWater.WaDE.Engines.Contracts.Attributes;
-using WesternStatesWater.WaDE.Engines.Contracts.Ogc;
 using WesternStatesWater.WaDE.Engines.Contracts.Ogc.Requests;
 using WesternStatesWater.WaDE.Engines.Handlers;
 using WesternStatesWater.WaDE.Tests.Helpers;
+using Link = WesternStatesWater.WaDE.Engines.Contracts.Ogc.Link;
 
 namespace WesternStatesWater.WaDE.Engines.Tests.FormattingEngine;
 
@@ -76,7 +77,7 @@ public class OgcFeaturesFormattingHandlerTests
             StringArrayProperty = ["string array!"]
         };
 
-        var request = new FeaturesRequest { Items = [feature] };
+        var request = new OgcFeaturesFormattingRequest { CollectionId = string.Empty, Items = [feature] };
         var response = await CreateHandler().Handle(request);
 
         // All attributes are keyed off the FeaturePropertyNameAttributes on the class properties.
@@ -102,7 +103,7 @@ public class OgcFeaturesFormattingHandlerTests
             BoolProperty = true
         };
 
-        var request = new FeaturesRequest { Items = [feature] };
+        var request = new OgcFeaturesFormattingRequest { CollectionId = string.Empty, Items = [feature] };
         var response = await CreateHandler().Handle(request);
 
         // All attributes are keyed off the FeaturePropertyNameAttributes on the class properties.
@@ -132,7 +133,7 @@ public class OgcFeaturesFormattingHandlerTests
         namedProperties.Length.Should().Be(10);
 
         var feature = new TestFeature();
-        var request = new FeaturesRequest { Items = [feature] };
+        var request = new OgcFeaturesFormattingRequest { CollectionId = string.Empty, Items = [feature] };
         var response = await CreateHandler().Handle(request);
 
         response.Features[0].Attributes.Count.Should().Be(namedProperties.Length);
@@ -141,8 +142,9 @@ public class OgcFeaturesFormattingHandlerTests
     [TestMethod]
     public async Task Features_HaveNoItems_ReturnsNoNextLink()
     {
-        var request = new FeaturesRequest()
+        var request = new OgcFeaturesFormattingRequest()
         {
+            CollectionId = string.Empty,
             Items = []
         };
 
@@ -175,8 +177,9 @@ public class OgcFeaturesFormattingHandlerTests
     public async Task SiteFeature_HasItems_IncludesNextPageLink()
     {
         // Arrange
-        var request = new FeaturesRequest()
+        var request = new OgcFeaturesFormattingRequest()
         {
+            CollectionId = Constants.SitesCollectionId,
             Items =
             [
                 new SiteFeature

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
@@ -44,35 +44,20 @@ public class OgcFeaturesFormattingHandler(IConfiguration configuration) : OgcFor
     }
 
     /// <summary>
-    /// Builds a GeoJson Feature "properties" using the FeaturePropertyNameAttribute as the property name.
+    /// Builds a GeoJson Feature "properties" using the <see cref="FeaturePropertyNameAttribute"/> as the property name.
     /// </summary>
     /// <param name="item">Feature item</param>
     /// <returns>Creates an AttributeTable from the derived FeatureBase type. Geometry is omitted from the table.</returns>
     private static AttributesTable BuildAttributesTable(FeatureBase item)
     {
         var properties = new AttributesTable();
-        foreach (var property in item.GetType().GetProperties().Where(prop => prop.Name != nameof(FeatureBase.Geometry)))
+        foreach (var property in item.GetType().GetProperties().Where(prop => prop.GetCustomAttribute<FeaturePropertyNameAttribute>() is not null))
         {
-            // TODO: check for missing attribute?
-            var attrName = property.GetCustomAttribute<FeaturePropertyNameAttribute>()?.GetName();
-            if (attrName == null)
-            {
-                throw new InvalidOperationException(
-                    $"{item.GetType()} property {property.Name} is missing {nameof(FeaturePropertyNameAttribute)}.");
-            }
+            var attrName = property.GetCustomAttribute<FeaturePropertyNameAttribute>()!.GetName();
+            
             properties.Add(attrName, property.GetValue(item));
         }
 
         return properties;
-    }
-
-    private static string GetCollectionId(FeatureBase feature)
-    {
-        return feature switch
-        {
-            SiteFeature => Constants.SitesCollectionId,
-            OverlayFeature => Constants.OverlaysCollectionId,
-            _ => throw new ArgumentOutOfRangeException(nameof(feature))
-        };
     }
 }

--- a/source/WesternStatesWater.WaDE.Managers.Api/Handlers/V2/OverlayFeaturesSearchRequestHandler.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Handlers/V2/OverlayFeaturesSearchRequestHandler.cs
@@ -26,8 +26,8 @@ public class OverlayFeaturesSearchRequestHandler(IFormattingEngine formattingEng
             await regulatoryOverlayAccessor.Search<OverlaySearchRequest, OverlaySearchResponse>(searchRequest);
 
         // Map to engine?
-        var formatRequest = searchResponse.Map<FeaturesRequest>();
-        var dtoResponse = await formattingEngine.Format<FeaturesRequest, FeaturesResponse>(formatRequest);
+        var formatRequest = searchResponse.Map<OgcFeaturesFormattingRequest>();
+        var dtoResponse = await formattingEngine.Format<OgcFeaturesFormattingRequest, OgcFeaturesFormattingResponse>(formatRequest);
         return dtoResponse.Map<OverlayFeaturesSearchResponse>();
     }
 }

--- a/source/WesternStatesWater.WaDE.Managers.Api/Handlers/V2/SiteFeaturesSearchRequestHandler.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Handlers/V2/SiteFeaturesSearchRequestHandler.cs
@@ -26,8 +26,8 @@ internal class SiteFeaturesSearchRequestHandler(IFormattingEngine formattingEngi
             await siteAccessor.Search<SiteSearchRequest, SiteSearchResponse>(searchRequest);
 
         // Map to engine?
-        var formatRequest = searchResponse.Map<FeaturesRequest>();
-        var dtoResponse = await formattingEngine.Format<FeaturesRequest, FeaturesResponse>(formatRequest);
+        var formatRequest = searchResponse.Map<OgcFeaturesFormattingRequest>();
+        var dtoResponse = await formattingEngine.Format<OgcFeaturesFormattingRequest, OgcFeaturesFormattingResponse>(formatRequest);
         return dtoResponse.Map<SiteFeaturesSearchResponse>();
     }
 }

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using AutoMapper;
+using WesternStatesWater.WaDE.Contracts.Api.OgcApi;
 
 namespace WesternStatesWater.WaDE.Managers.Api.Mapping;
 
@@ -22,9 +23,9 @@ public class OgcApiProfile : Profile
         CreateMap<Engines.Contracts.Ogc.Spatial, Contracts.Api.OgcApi.Spatial>();
         CreateMap<Engines.Contracts.Ogc.Temporal, Contracts.Api.OgcApi.Temporal>();
         CreateMap<Engines.Contracts.Ogc.Responses.CollectionsResponse, Contracts.Api.OgcApi.CollectionsResponse>();
-        CreateMap<Engines.Contracts.Ogc.Responses.FeaturesResponse,
+        CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
             Contracts.Api.Responses.V2.SiteFeaturesSearchResponse>();
-        CreateMap<Engines.Contracts.Ogc.Responses.FeaturesResponse,
+        CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
             Contracts.Api.Responses.V2.OverlayFeaturesSearchResponse>();
 
         // Managers -> Accessors
@@ -46,13 +47,15 @@ public class OgcApiProfile : Profile
 
         // Accessor -> Engines
         CreateMap<Accessors.Contracts.Api.V2.Responses.SiteSearchResponse,
-                Engines.Contracts.Ogc.Requests.FeaturesRequest>()
+                Engines.Contracts.Ogc.Requests.OgcFeaturesFormattingRequest>()
+            .ForMember(dest => dest.CollectionId, opt => opt.MapFrom(src => Constants.SitesCollectionId))
             .ForMember(dest => dest.Items,
                 opt => opt.MapFrom((src, a, b, c) =>
                     c.Mapper.Map<List<Engines.Contracts.SiteFeature>>(src.Sites)));
 
         CreateMap<Accessors.Contracts.Api.V2.Responses.OverlaySearchResponse,
-                Engines.Contracts.Ogc.Requests.FeaturesRequest>()
+                Engines.Contracts.Ogc.Requests.OgcFeaturesFormattingRequest>()
+            .ForMember(dest => dest.CollectionId, opt => opt.MapFrom(src => Constants.OverlaysCollectionId))
             .ForMember(dest => dest.Items,
                 opt => opt.MapFrom((src, a, b, c) =>
                     c.Mapper.Map<List<Engines.Contracts.OverlayFeature>>(src.Overlays)));

--- a/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/OverlayFeaturesSearchRequestHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/OverlayFeaturesSearchRequestHandlerTests.cs
@@ -34,10 +34,10 @@ public class OverlayFeaturesSearchRequestHandlerTests
                 mock.Search<OverlaySearchRequest, OverlaySearchResponse>(Arg.IsAny<OverlaySearchRequest>()))
             .ReturnsAsync(mockSearchResponse);
 
-        var mockFormatResponse = new FeaturesResponse();
+        var mockFormatResponse = new OgcFeaturesFormattingResponse();
         _formattingEngineMock.Arrange(mock =>
-                mock.Format<FeaturesRequest, FeaturesResponse>(
-                    Arg.IsAny<FeaturesRequest>()))
+                mock.Format<OgcFeaturesFormattingRequest, OgcFeaturesFormattingResponse>(
+                    Arg.IsAny<OgcFeaturesFormattingRequest>()))
             .ReturnsAsync(mockFormatResponse);
 
         // Act
@@ -70,13 +70,13 @@ public class OverlayFeaturesSearchRequestHandlerTests
                 mock.Search<OverlaySearchRequest, OverlaySearchResponse>(Arg.IsAny<OverlaySearchRequest>()))
             .ReturnsAsync(mockSearchResponse);
 
-        var mockFormatResponse = new FeaturesResponse
+        var mockFormatResponse = new OgcFeaturesFormattingResponse
         {
             Features = [],
             Links = []
         };
         _formattingEngineMock.Arrange(mock =>
-                mock.Format<FeaturesRequest, FeaturesResponse>(Arg.IsAny<FeaturesRequest>()))
+                mock.Format<OgcFeaturesFormattingRequest, OgcFeaturesFormattingResponse>(Arg.IsAny<OgcFeaturesFormattingRequest>()))
             .ReturnsAsync(mockFormatResponse);
 
         // Act

--- a/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/SiteFeaturesSearchRequestHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/SiteFeaturesSearchRequestHandlerTests.cs
@@ -34,10 +34,10 @@ public class SiteFeaturesSearchRequestHandlerTests
                 mock.Search<SiteSearchRequest, SiteSearchResponse>(Arg.IsAny<SiteSearchRequest>()))
             .ReturnsAsync(mockSearchResponse);
 
-        var mockFormatResponse = new FeaturesResponse();
+        var mockFormatResponse = new OgcFeaturesFormattingResponse();
         _formattingEngineMock.Arrange(mock =>
-                mock.Format<FeaturesRequest, FeaturesResponse>(
-                    Arg.IsAny<FeaturesRequest>()))
+                mock.Format<OgcFeaturesFormattingRequest, OgcFeaturesFormattingResponse>(
+                    Arg.IsAny<OgcFeaturesFormattingRequest>()))
             .ReturnsAsync(mockFormatResponse);
 
         // Act
@@ -70,13 +70,13 @@ public class SiteFeaturesSearchRequestHandlerTests
                 mock.Search<SiteSearchRequest, SiteSearchResponse>(Arg.IsAny<SiteSearchRequest>()))
             .ReturnsAsync(mockSearchResponse);
 
-        var mockFormatResponse = new FeaturesResponse
+        var mockFormatResponse = new OgcFeaturesFormattingResponse
         {
             Features = [],
             Links = []
         };
         _formattingEngineMock.Arrange(mock =>
-                mock.Format<FeaturesRequest, FeaturesResponse>(Arg.IsAny<FeaturesRequest>()))
+                mock.Format<OgcFeaturesFormattingRequest, OgcFeaturesFormattingResponse>(Arg.IsAny<OgcFeaturesFormattingRequest>()))
             .ReturnsAsync(mockFormatResponse);
 
         // Act


### PR DESCRIPTION
@zlannin I wanted to demonstrate a different approach to the format/reflection tests in this PR, for discussion. Highlights:

- I tried to separate out some of the concerns between different tests, and remove control flow (if/else) especially when nested in loops.
- 1 test to verify that all our `FeatureBase` implementers use the `FeaturePropertyName` attribute on all their properties. This way we can take out the `InvalidOperationException` in the engine. However, there _could_ still be debugging value in throwing the exception (maybe a `Debug.Assert`), because otherwise you would need to run the unit test to know that you'd missed something. Thoughts on that?
- 1 test to verify all properties of all different types are set on a test feature class.
- 1 test to verify that nullable properties are set to null.
- 1 test to verify that all (and only) properties with the `FeaturePropertyName` attribute get added to the attribute table.