### PR TITLE
Moved Accessor Search Geometery into SpatialSearchCriteria

### DIFF
--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/SpatialRelationType.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/SpatialRelationType.cs
@@ -1,0 +1,6 @@
+namespace WesternStatesWater.WaDE.Accessors.Contracts.Api;
+
+public enum SpatialRelationType
+{
+    Intersects = 0
+}

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/SpatialSearchCriteria.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/SpatialSearchCriteria.cs
@@ -1,0 +1,9 @@
+using NetTopologySuite.Geometries;
+
+namespace WesternStatesWater.WaDE.Accessors.Contracts.Api;
+
+public class SpatialSearchCriteria
+{
+    public Geometry Geometry { get; set; }
+    public SpatialRelationType SpatialRelationType { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/AllocationSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/AllocationSearchRequest.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using NetTopologySuite.Geometries;
 
 namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Requests;
 
@@ -11,5 +10,5 @@ public class AllocationSearchRequest : SearchRequestBase
 
     public string LastKey { get; set; }
     
-    public Geometry FilterBoundary { get; set; }
+    public SpatialSearchCriteria GeometrySearch { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/OverlaySearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/OverlaySearchRequest.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using NetTopologySuite.Geometries;
 
 namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Requests;
 
@@ -7,6 +6,6 @@ public class OverlaySearchRequest : SearchRequestBase
 {
     public List<string> OverlayUuids { get; set; }
     public List<string> SiteUuids { get; set; }
-    public Geometry FilterBoundary { get; set; }
+    public SpatialSearchCriteria GeometrySearch { get; set; }
     public string LastKey { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/SiteSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/SiteSearchRequest.cs
@@ -1,9 +1,7 @@
-using NetTopologySuite.Geometries;
-
 namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Requests;
 
 public class SiteSearchRequest : SearchRequestBase
 {
-    public Geometry FilterBoundary { get; set; }
+    public SpatialSearchCriteria GeometrySearch { get; set; }
     public string LastSiteUuid { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/AllocationSearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/AllocationSearchHandlerTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NetTopologySuite.IO;
+using WesternStatesWater.WaDE.Accessors.Contracts.Api;
 using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Requests;
 using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Responses;
 using WesternStatesWater.WaDE.Accessors.EntityFramework;
@@ -239,8 +240,12 @@ public class AllocationSearchHandlerTests : DbTestBase
         // Visualize all coordinates: https://wktmap.com/?afc484da
         var request = new AllocationSearchRequest
         {
-            FilterBoundary = wktReader.Read(
-                "POLYGON ((-112.08792189270426 39.44602478526929, -112.08792189270426 39.172494625547614, -111.73175117928515 39.172494625547614, -111.73175117928515 39.44602478526929, -112.08792189270426 39.44602478526929))"),
+            GeometrySearch = new SpatialSearchCriteria
+            {
+                Geometry = wktReader.Read(
+                    "POLYGON ((-112.08792189270426 39.44602478526929, -112.08792189270426 39.172494625547614, -111.73175117928515 39.172494625547614, -111.73175117928515 39.44602478526929, -112.08792189270426 39.44602478526929))"),
+                SpatialRelationType = SpatialRelationType.Intersects
+            },
             Limit = 5
         };
         

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NetTopologySuite.Geometries;
+using WesternStatesWater.WaDE.Accessors.Contracts.Api;
 using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Requests;
 using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Responses;
 using WesternStatesWater.WaDE.Accessors.EntityFramework;
@@ -209,7 +210,11 @@ public class OverlaySearchHandlerTests : DbTestBase
 
         var request = new OverlaySearchRequest
         {
-            FilterBoundary = CreateUtahPolygon(),
+            GeometrySearch = new SpatialSearchCriteria
+            {
+                Geometry = CreateUtahPolygon(),
+                SpatialRelationType = SpatialRelationType.Intersects
+            },
             Limit = 10
         };
 

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/SiteSearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/SiteSearchHandlerTests.cs
@@ -107,7 +107,11 @@ public class SiteSearchHandlerTests : DbTestBase
 
         var request = new SiteSearchRequest
         {
-            FilterBoundary = filterPolygon,
+            GeometrySearch = new SpatialSearchCriteria
+            {
+                Geometry = filterPolygon,
+                SpatialRelationType = SpatialRelationType.Intersects
+            },
             Limit = 10
         };
         var response = await ExecuteHandler(request);

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
@@ -32,15 +32,23 @@ public class OgcApiProfile : Profile
 
         // Managers -> Accessors
         CreateMap<Contracts.Api.Requests.V2.SiteFeaturesItemRequest,
+            Accessors.Contracts.Api.SpatialSearchCriteria>()
+            .ForMember(dest => dest.Geometry, mem => mem.ConvertUsing(new BoundingBoxConverter(), src => src.Bbox))
+            .ForMember(dest => dest.SpatialRelationType, mem => mem.MapFrom(src => AccessorApi.SpatialRelationType.Intersects));
+        
+        CreateMap<Contracts.Api.Requests.V2.SiteFeaturesItemRequest,
                 Accessors.Contracts.Api.V2.Requests.SiteSearchRequest>()
-            .ForMember(dest => dest.FilterBoundary,
-                mem => mem.ConvertUsing(new BoundingBoxConverter(), src => src.Bbox))
+            .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.LastSiteUuid, mem => mem.MapFrom(src => src.Next));
+        
+        CreateMap<Contracts.Api.Requests.V2.OverlayFeaturesItemRequest,
+                Accessors.Contracts.Api.SpatialSearchCriteria>()
+            .ForMember(dest => dest.Geometry, mem => mem.ConvertUsing(new BoundingBoxConverter(), src => src.Bbox))
+            .ForMember(dest => dest.SpatialRelationType, mem => mem.MapFrom(src => AccessorApi.SpatialRelationType.Intersects));
 
         CreateMap<Contracts.Api.Requests.V2.OverlayFeaturesItemRequest,
                 Accessors.Contracts.Api.V2.Requests.OverlaySearchRequest>()
-            .ForMember(dest => dest.FilterBoundary,
-                mem => mem.ConvertUsing(new BoundingBoxConverter(), src => src.Bbox))
+            .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.OverlayUuids,
                 mem => mem.ConvertUsing(new CommaStringToListConverter(), src => src.OverlayUuids))
             .ForMember(dest => dest.SiteUuids,
@@ -48,9 +56,13 @@ public class OgcApiProfile : Profile
             .ForMember(dest => dest.LastKey, mem => mem.MapFrom(src => src.Next));
         
         CreateMap<Contracts.Api.Requests.V2.RightFeaturesItemRequest,
+                Accessors.Contracts.Api.SpatialSearchCriteria>()
+            .ForMember(dest => dest.Geometry, mem => mem.ConvertUsing(new BoundingBoxConverter(), src => src.Bbox))
+            .ForMember(dest => dest.SpatialRelationType, mem => mem.MapFrom(src => AccessorApi.SpatialRelationType.Intersects));
+        
+        CreateMap<Contracts.Api.Requests.V2.RightFeaturesItemRequest,
         Accessors.Contracts.Api.V2.Requests.AllocationSearchRequest>()
-            .ForMember(dest => dest.FilterBoundary,
-                mem => mem.ConvertUsing(new BoundingBoxConverter(), src => src.Bbox))
+            .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.AllocationUuid,
                 opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.AllocationUuids))
             .ForMember(dest => dest.SiteUuid, opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.SiteUuids))

--- a/source/WesternStatesWater.WaDE.Managers.Tests/DtoMapper.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/DtoMapper.cs
@@ -78,7 +78,7 @@ namespace WesternStatesWater.WaDE.Managers.Tests
             };
 
             var response = request.Map<SiteSearchRequest>();
-            response.FilterBoundary.ToString().Should().Be(expected);
+            response.GeometrySearch.Geometry.ToString().Should().Be(expected);
         }
 
         [TestMethod]
@@ -90,7 +90,7 @@ namespace WesternStatesWater.WaDE.Managers.Tests
             };
 
             var response = request.Map<SiteSearchRequest>();
-            response.FilterBoundary.Should().BeNull();
+            response.GeometrySearch.Geometry.Should().BeNull();
         }
     }
 }


### PR DESCRIPTION
This will allow in the future to support other spatial type searches like Contains, Disjoint, etc.