### PR TITLE
Search Sites by States

### DIFF
--- a/source/WaDEApiFunctions/v2/SitesFunction.cs
+++ b/source/WaDEApiFunctions/v2/SitesFunction.cs
@@ -5,7 +5,6 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
-using OfficeOpenXml.FormulaParsing.Excel.Functions.Logical;
 using WesternStatesWater.WaDE.Contracts.Api;
 using WesternStatesWater.WaDE.Contracts.Api.OgcApi;
 using WesternStatesWater.WaDE.Contracts.Api.Requests;

--- a/source/WaDEApiFunctions/v2/SitesFunction.cs
+++ b/source/WaDEApiFunctions/v2/SitesFunction.cs
@@ -64,6 +64,9 @@ public class WaterSitesFunction(
     [OpenApiParameter("siteTypes", Type = typeof(string[]), In = ParameterLocation.Query,
         Explode = false,
         Required = false, Description = "Site Types")]
+    [OpenApiParameter("states", Type = typeof(string[]), In = ParameterLocation.Query,
+        Explode = false,
+        Required = false, Description = "State abbreviations")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
         bodyType: typeof(Collection),
         Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
@@ -83,7 +86,8 @@ public class WaterSitesFunction(
             Bbox = req.Query["bbox"],
             Limit = req.Query["limit"],
             Next = req.Query["next"],
-            SiteTypes = req.Query["siteTypes"]
+            SiteTypes = req.Query["siteTypes"],
+            States = req.Query["states"]
         };
         var response = await waterResourceManager.Search<SiteFeaturesSearchRequestBase, SiteFeaturesSearchResponse>(request);
 

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/SiteSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/SiteSearchRequest.cs
@@ -7,4 +7,5 @@ public class SiteSearchRequest : SearchRequestBase
     public SpatialSearchCriteria GeometrySearch { get; set; }
     public string LastSiteUuid { get; set; }
     public List<string> SiteTypes { get; set; }
+    public List<string> States { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/SiteSearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/SiteSearchHandlerTests.cs
@@ -282,6 +282,26 @@ public class SiteSearchHandlerTests : DbTestBase
         response.Sites.Select(s => s.SiteType).Should().BeEquivalentTo(siteTypeA.WaDEName, siteTypeB.WaDEName);
         response.Sites.Select(s => s.SiteUuid).Should().BeEquivalentTo(siteA.SiteUuid, siteB.SiteUuid);
     }
+    
+    [TestMethod]
+    public async Task SiteAccessor_StatesFilter_ReturnsCorrectSites()
+    {
+        await using var db = new WaDEContext(Configuration.GetConfiguration());
+        
+        var siteA = await SitesDimBuilder.Load(db);
+        var siteB = await SitesDimBuilder.Load(db);
+        await SitesDimBuilder.Load(db);
+
+        var request = new SiteSearchRequest
+        {
+            States = [siteA.StateCv, siteB.StateCv],
+            Limit = 10
+        };
+        var response = await ExecuteHandler(request);
+        response.Sites.Should().HaveCount(2);
+        response.Sites.Select(s => s.State).Should().BeEquivalentTo(siteA.StateCv, siteB.StateCv);
+        response.Sites.Select(s => s.SiteUuid).Should().BeEquivalentTo(siteA.SiteUuid, siteB.SiteUuid);
+    }
 
     private async Task<SiteSearchResponse> ExecuteHandler(SiteSearchRequest request)
     {

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -30,6 +30,11 @@ public static class QueryableExtensions
             query = query.Where(s => filters.SiteTypes.Contains(s.SiteTypeCvNavigation.WaDEName));
         }
 
+        if (filters.States != null && filters.States.Count != 0)
+        {
+            query = query.Where(s => filters.States.Contains(s.StateCv));
+        }
+
         return query;
     }
 

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/SiteFeaturesItemRequest.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/SiteFeaturesItemRequest.cs
@@ -3,4 +3,5 @@ namespace WesternStatesWater.WaDE.Contracts.Api.Requests.V2;
 public class SiteFeaturesItemRequest : SiteFeaturesSearchRequestBase
 {
     public string SiteTypes { get; set; }
+    public string States { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
@@ -45,11 +45,13 @@ public class OgcApiProfile : Profile
                 Accessors.Contracts.Api.V2.Requests.SiteSearchRequest>()
             .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.LastSiteUuid, mem => mem.MapFrom(src => src.Next))
-            .ForMember(dest => dest.SiteTypes, mem => mem.ConvertUsing(new CommaStringToListConverter(), src => src.SiteTypes));
-
+            .ForMember(dest => dest.SiteTypes, mem => mem.ConvertUsing(new CommaStringToListConverter(), src => src.SiteTypes))
+            .ForMember(dest => dest.States, mem => mem.ConvertUsing(new CommaStringToListConverter(), src => src.States));
+        
         CreateMap<Contracts.Api.Requests.V2.SiteFeaturesAreaRequest,
                 Accessors.Contracts.Api.V2.Requests.SiteSearchRequest>()
             .ForMember(dest => dest.SiteTypes, mem => mem.Ignore())
+            .ForMember(dest => dest.States, mem => mem.Ignore())
             .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.LastSiteUuid, mem => mem.MapFrom(src => src.Next));
         


### PR DESCRIPTION
Updated Site Items endpoint to support a comma separated query string parameter `states`.

Example: `/collections/sites/items?states=NV,OR`