### PR TITLE
Filter Water Rights by Water Source Types

### DIFF
--- a/source/WaDEApiFunctions/v2/RightsFunction.cs
+++ b/source/WaDEApiFunctions/v2/RightsFunction.cs
@@ -64,6 +64,9 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
     [OpenApiParameter("siteUuids", Type = typeof(string[]), In = ParameterLocation.Query,
         Explode = false,
         Required = false, Description = "Site UUIDs")]
+    [OpenApiParameter("waterSourceTypes", Type = typeof(string[]), In = ParameterLocation.Query,
+        Explode = false,
+        Required = false, Description = "Water Source Types")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
         bodyType: typeof(Collection),
         Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
@@ -84,7 +87,8 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
             Limit = req.Query["limit"],
             Next = req.Query["next"],
             AllocationUuids = req.Query["allocationUuids"],
-            SiteUuids = req.Query["siteUuids"]
+            SiteUuids = req.Query["siteUuids"],
+            WaterSourceTypes = req.Query["waterSourceTypes"]
         };
         var response = await waterResourceManager.Search<RightFeaturesSearchRequestBase, RightFeaturesSearchResponse>(request);
         

--- a/source/WaDEApiFunctions/v2/RightsFunction.cs
+++ b/source/WaDEApiFunctions/v2/RightsFunction.cs
@@ -91,8 +91,7 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
             Next = req.Query["next"],
             AllocationUuids = req.Query["allocationUuids"],
             SiteUuids = req.Query["siteUuids"],
-            States = req.Query["states"]
-            SiteUuids = req.Query["siteUuids"],
+            States = req.Query["states"],
             WaterSourceTypes = req.Query["waterSourceTypes"]
         };
         var response = await waterResourceManager.Search<RightFeaturesSearchRequestBase, RightFeaturesSearchResponse>(request);

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/AllocationSearchItem.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/AllocationSearchItem.cs
@@ -35,4 +35,5 @@ public class AllocationSearchItem
     public List<string> BeneficialUses { get; set; }
     public string Organization { get; set; }
     public bool ExemptOfVolumeFlowPriority { get; set; }
+    public List<WaterSourceSummary> WaterSources { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/AllocationSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/AllocationSearchRequest.cs
@@ -11,4 +11,6 @@ public class AllocationSearchRequest : SearchRequestBase
     public string LastKey { get; set; }
     
     public SpatialSearchCriteria GeometrySearch { get; set; }
+    
+    public List<string> WaterSourceTypes { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Responses/SearchResponseBase.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Responses/SearchResponseBase.cs
@@ -4,6 +4,5 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Responses;
 
 public abstract class SearchResponseBase : ResponseBase
 {
-    public int MatchedCount { get; set; }
     public string LastUuid { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/AllocationSearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/AllocationSearchHandlerTests.cs
@@ -10,6 +10,7 @@ using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Requests;
 using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Responses;
 using WesternStatesWater.WaDE.Accessors.EntityFramework;
 using WesternStatesWater.WaDE.Accessors.Handlers;
+using WesternStatesWater.WaDE.Accessors.Mapping;
 using WesternStatesWater.WaDE.Tests.Helpers;
 using WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework;
 
@@ -41,7 +42,6 @@ public class AllocationSearchHandlerTests : DbTestBase
 
         // Assert
         response.Allocations.Should().HaveCount(5);
-        response.MatchedCount.Should().Be(5);
         response.LastUuid.Should().BeNull();
     }
     
@@ -67,7 +67,6 @@ public class AllocationSearchHandlerTests : DbTestBase
 
         // Assert
         response.Allocations.Should().HaveCount(3);
-        response.MatchedCount.Should().Be(5);
         response.LastUuid.Should()
             .Be(dbAllocations.OrderBy(a => a.AllocationUUID).Select(a => a.AllocationUUID).ElementAt(3));
     }
@@ -255,6 +254,68 @@ public class AllocationSearchHandlerTests : DbTestBase
         response.Allocations.Select(a => a.AllocationUUID).Should().BeEquivalentTo(
             allocationWithOneSiteInBoundary.AllocationUUID,
             allocationWithSiteInBoundary.AllocationUUID);
+    }
+
+    [TestMethod]
+    public async Task Handler_FilterWaterSourceTypes_ShouldReturnAllocationsWithWaterSourceType()
+    {
+        await using var db = new WaDEContext(Configuration.GetConfiguration());
+
+        var waterSourceTypeA = await WaterSourceTypeBuilder.Load(db);
+        var waterSourceTypeB = await WaterSourceTypeBuilder.Load(db);
+
+        var waterSourceA = await WaterSourcesDimBuilder.Load(db, new WaterSourcesDimBuilderOptions
+        {
+            WaterSourceType = waterSourceTypeA
+        });
+        var waterSourceB = await WaterSourcesDimBuilder.Load(db, new WaterSourcesDimBuilderOptions
+        {
+            WaterSourceType = waterSourceTypeB
+        });
+
+        var siteA = await SitesDimBuilder.Load(db);
+        var siteB = await SitesDimBuilder.Load(db);
+
+        await WaterSourceBridgeSitesFactBuilder.Load(db,
+            new WaterSourceBridgeSitesFactBuilderOptions
+            {
+                SitesDim = siteA,
+                WaterSourcesDim = waterSourceA
+            });
+        await WaterSourceBridgeSitesFactBuilder.Load(db,
+            new WaterSourceBridgeSitesFactBuilderOptions
+            {
+                SitesDim = siteB,
+                WaterSourcesDim = waterSourceB
+            });
+        
+        var allocationA = await AllocationAmountsFactBuilder.Load(db);
+        var allocationB = await AllocationAmountsFactBuilder.Load(db);
+        
+        await AllocationBridgeSitesFactBuilder.Load(db, new AllocationBridgeSitesFactBuilderOptions
+        {
+            SitesDim = siteA,
+            AllocationAmountsFact = allocationA
+        });
+        await AllocationBridgeSitesFactBuilder.Load(db, new AllocationBridgeSitesFactBuilderOptions
+        {
+            SitesDim = siteB,
+            AllocationAmountsFact = allocationB
+        });
+        
+        var request = new AllocationSearchRequest
+        {
+            WaterSourceTypes = [waterSourceTypeA.WaDEName],
+            Limit = 10
+        };
+        
+        var response = await ExecuteHandler(request);
+        
+        response.Allocations.Should().HaveCount(1);
+        response.Allocations.Select(a => a.AllocationUUID).Should().BeEquivalentTo(allocationA.AllocationUUID);
+        response.Allocations[0].WaterSources.Should()
+            .BeEquivalentTo([waterSourceA.Map<WaterSourceSummary>()]);
+
     }
     
     private async Task<AllocationSearchResponse> ExecuteHandler(AllocationSearchRequest request)

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
@@ -41,7 +41,6 @@ public class OverlaySearchHandlerTests : DbTestBase
 
         // Assert
         response.Overlays.Should().HaveCount(5);
-        response.MatchedCount.Should().Be(5);
         response.LastUuid.Should().BeNull();
     }
     
@@ -67,7 +66,6 @@ public class OverlaySearchHandlerTests : DbTestBase
 
         // Assert
         response.Overlays.Should().HaveCount(3);
-        response.MatchedCount.Should().Be(5);
         response.LastUuid.Should()
             .Be(dbOverlays.OrderBy(o => o.RegulatoryOverlayUuid).Select(o => o.RegulatoryOverlayUuid)
                 .ElementAt(3));

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/SiteSearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/SiteSearchHandlerTests.cs
@@ -42,7 +42,6 @@ public class SiteSearchHandlerTests : DbTestBase
         
         // Assert
         response.Sites.Should().HaveCount(5);
-        response.MatchedCount.Should().Be(5);
         response.LastUuid.Should().BeNull();
     }
     
@@ -68,7 +67,6 @@ public class SiteSearchHandlerTests : DbTestBase
         
         // Assert
         response.Sites.Should().HaveCount(3);
-        response.MatchedCount.Should().Be(5);
         response.LastUuid.Should()
             .Be(dbSites.OrderBy(s => s.SiteUuid).Select(s => s.SiteUuid).ElementAt(2));
     }

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/TimeSeriesSearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/TimeSeriesSearchHandlerTests.cs
@@ -40,7 +40,6 @@ public class TimeSeriesSearchHandlerTests : DbTestBase
 
         // Assert
         response.TimeSeries.Should().HaveCount(5);
-        response.MatchedCount.Should().Be(5);
         response.LastUuid.Should().BeNull();
     }
     
@@ -66,7 +65,6 @@ public class TimeSeriesSearchHandlerTests : DbTestBase
 
         // Assert
         response.TimeSeries.Should().HaveCount(3);
-        response.MatchedCount.Should().Be(5);
         response.LastUuid.Should()
             .Be(dbTimeSeries.OrderBy(ts => ts.SiteVariableAmountId)
                 .Select(ts => ts.SiteVariableAmountId)

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -69,6 +69,13 @@ public static class QueryableExtensions
                 bridge => filters.SiteUuid.Contains(bridge.Site.SiteUuid)));
         }
 
+        if (filters.WaterSourceTypes != null && filters.WaterSourceTypes.Count != 0)
+        {
+            query = query.Where(x => x.AllocationBridgeSitesFact.Any(
+                bridge => bridge.Site.WaterSourceBridgeSitesFact.Any(
+                    ws => filters.WaterSourceTypes.Contains(ws.WaterSource.WaterSourceTypeCvNavigation.WaDEName))));
+        }
+
         if (!string.IsNullOrWhiteSpace(filters.LastKey))
         {
             query = query.Where(x => x.AllocationUUID.CompareTo(filters.LastKey) > 0);

--- a/source/WesternStatesWater.WaDE.Accessors/Handlers/AllocationSearchHandler.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Handlers/AllocationSearchHandler.cs
@@ -20,23 +20,16 @@ public class AllocationSearchHandler(IConfiguration configuration)
     {
         await using var db = new WaDEContext(configuration);
 
-        var query = db.AllocationAmountsFact
+        var allocations = await db.AllocationAmountsFact
             .AsNoTracking()
             .OrderBy(alloc => alloc.AllocationUUID)
             .ApplySearchFilters(request)
-            .AsQueryable();
-        
-        // Fetch the number of matched records
-        var count = await query.CountAsync();
-
-        var allocations = await query
             .ApplyLimit(request)
             .ProjectTo<AllocationSearchItem>(DtoMapper.Configuration)
             .ToListAsync();
 
         return new AllocationSearchResponse
         {
-            MatchedCount = count,
             LastUuid = allocations.Count <= request.Limit ? null : allocations[^1].AllocationUUID,
             Allocations = allocations.Take(request.Limit).ToList()
         };

--- a/source/WesternStatesWater.WaDE.Accessors/Handlers/OverlaySearchHandler.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Handlers/OverlaySearchHandler.cs
@@ -20,23 +20,16 @@ public class OverlaySearchHandler(IConfiguration configuration)
     {
         await using var db = new WaDEContext(configuration);
 
-        var query = db.RegulatoryOverlayDim
+        var overlays =await  db.RegulatoryOverlayDim
             .AsNoTracking()
             .OrderBy(o => o.RegulatoryOverlayUuid)
             .ApplySearchFilters(request)
-            .AsQueryable();
-        
-        // Fetch the number of matched records
-        var count = await query.CountAsync();
-        
-        var overlays = await query
             .ApplyLimit(request)
             .ProjectTo<OverlaySearchItem>(DtoMapper.Configuration)
             .ToListAsync();
-
+        
         return new OverlaySearchResponse
         {
-            MatchedCount = count,
             LastUuid = overlays.Count <= request.Limit ? null : overlays[^1].OverlayUuid,
             Overlays = overlays.Take(request.Limit).ToList()
         };

--- a/source/WesternStatesWater.WaDE.Accessors/Handlers/TimeSeriesSearchHandler.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Handlers/TimeSeriesSearchHandler.cs
@@ -20,23 +20,16 @@ public class TimeSeriesSearchHandler(IConfiguration configuration)
     {
         await using var db = new WaDEContext(configuration);
 
-        var query = db.SiteVariableAmountsFact
+        var timeSeries = await db.SiteVariableAmountsFact
             .AsNoTracking()
             .OrderBy(ts => ts.SiteVariableAmountId)
             .ApplySearchFilters(request)
-            .AsQueryable();
-        
-        // Fetch the number of matched records
-        var count = await query.CountAsync();
-        
-        var timeSeries = await query
             .ApplyLimit(request)
             .ProjectTo<TimeSeriesSearchItem>(DtoMapper.Configuration)
             .ToListAsync();
-
+            
         return new TimeSeriesSearchResponse
         {
-            MatchedCount = count,
             LastUuid = timeSeries.Count <= request.Limit ? null : timeSeries[^1].SiteVariableAmountId.ToString(),
             TimeSeries = timeSeries.Take(request.Limit).ToList()
         };

--- a/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
@@ -90,7 +90,10 @@ public class ApiV2Profile : Profile
                 b => b.MapFrom(c => c.AllocationBridgeBeneficialUsesFact.Select(d => d.BeneficialUseCV)))
             .ForMember(a => a.DataPublicationDate, b => b.MapFrom(c => c.DataPublicationDate.Date))
             .ForMember(a => a.SitesUUIDs,
-                b => b.MapFrom(c => c.AllocationBridgeSitesFact.Select(d => d.Site.SiteUuid)));
+                b => b.MapFrom(c => c.AllocationBridgeSitesFact.Select(d => d.Site.SiteUuid)))
+            .ForMember(a => a.WaterSources,
+                b => b.MapFrom(c => c.AllocationBridgeSitesFact
+                    .SelectMany(bridge => bridge.Site.WaterSourceBridgeSitesFact.Select(ws => ws.WaterSource))));
 
         CreateMap<EF.SiteVariableAmountsFact, TimeSeriesSearchItem>()
             .ForMember(a => a.WaterSourceUUID, b => b.MapFrom(c => c.WaterSource.WaterSourceUuid))

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/RightFeaturesItemRequest.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/RightFeaturesItemRequest.cs
@@ -4,4 +4,5 @@ public class RightFeaturesItemRequest : RightFeaturesSearchRequestBase
 {
     public string AllocationUuids { get; set; }
     public string SiteUuids { get; set; }
+    public string WaterSourceTypes { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Engines.Contracts/RightFeature.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/RightFeature.cs
@@ -44,4 +44,6 @@ public class RightFeature : FeatureBase
     public List<string> BeneficialUses { get; set; }
     [JsonPropertyName("exmptVolFlowPriority")]
     public bool ExemptOfVolumeFlowPriority { get; set; }
+    [JsonPropertyName("waterSources")]
+    public List<WaterSourceSummary> WaterSources { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
@@ -98,6 +98,8 @@ public class OgcApiProfile : Profile
             .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.AllocationUuid,
                 opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.AllocationUuids))
+            .ForMember(dest => dest.WaterSourceTypes,
+                opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.WaterSourceTypes))
             .ForMember(dest => dest.SiteUuid, opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.SiteUuids))
             .ForMember(dest => dest.LastKey, opt => opt.MapFrom(src => src.Next));
         
@@ -105,6 +107,7 @@ public class OgcApiProfile : Profile
                 Accessors.Contracts.Api.V2.Requests.AllocationSearchRequest>()
             .ForMember(dest => dest.AllocationUuid, mem => mem.Ignore())
             .ForMember(dest => dest.SiteUuid, mem => mem.Ignore())
+            .ForMember(dest => dest.WaterSourceTypes, mem => mem.Ignore())
             .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.LastKey, opt => opt.MapFrom(src => src.Next));
 


### PR DESCRIPTION
Updated API Endpoint Water Rights Features Query to support `waterSourceTypes` query string parameter. Can send in one or more water source types and the response will include any water rights whose sites include the filtered water source type. Additionally added `waterSources` to the feature properties for water rights.

Additionally removed MatchedCount from searches as it was killing performance.

```json
{
      "type": "Feature",
      "id": "AKwr_WR1100000",
      "geometry": null,
      "properties": {
        "nId": "1100000",
        "owner": "Knutson James W",
        "appDate": null,
        "priorityDate": null,
        "legalStatus": "CERT ISSUED",
        "expires": null,
        "acreage": 0,
        "basis": "WaDE Blank",
        "start": null,
        "end": null,
        "cropDutyAmt": null,
        "cfs": 0,
        "af": 0,
        "popServed": null,
        "generatedPowerCap": null,
        "commWaterSupply": null,
        "sdwis": null,
        "varType": "Allocation",
        "beneficialUses": [
          "WaDE Blank"
        ],
        "exmptVolFlowPriority": true,
        "waterSources": [
          {
            "id": "AKwr_WwadeId1",
            "nId": "wadeId1",
            "name": "WaDE Blank",
            "sourceType": "Groundwater",
            "type": "Fresh"
          }
        ]
      }
```