### PR TITLE
Filter Water Rights by Beneficial Uses

### DIFF
--- a/source/WaDEApiFunctions/v2/RightsFunction.cs
+++ b/source/WaDEApiFunctions/v2/RightsFunction.cs
@@ -67,6 +67,9 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
     [OpenApiParameter("waterSourceTypes", Type = typeof(string[]), In = ParameterLocation.Query,
         Explode = false,
         Required = false, Description = "Water Source Types")]
+    [OpenApiParameter("beneficialUses", Type = typeof(string[]), In = ParameterLocation.Query,
+        Explode = false,
+        Required = false, Description = "Beneficial Uses")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
         bodyType: typeof(Collection),
         Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
@@ -88,7 +91,8 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
             Next = req.Query["next"],
             AllocationUuids = req.Query["allocationUuids"],
             SiteUuids = req.Query["siteUuids"],
-            WaterSourceTypes = req.Query["waterSourceTypes"]
+            WaterSourceTypes = req.Query["waterSourceTypes"],
+            BeneficialUses = req.Query["beneficialUses"]
         };
         var response = await waterResourceManager.Search<RightFeaturesSearchRequestBase, RightFeaturesSearchResponse>(request);
         

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/AllocationSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/AllocationSearchRequest.cs
@@ -13,4 +13,6 @@ public class AllocationSearchRequest : SearchRequestBase
     public SpatialSearchCriteria GeometrySearch { get; set; }
     
     public List<string> WaterSourceTypes { get; set; }
+    
+    public List<string> BeneficialUses { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -75,6 +75,12 @@ public static class QueryableExtensions
                 bridge => bridge.Site.WaterSourceBridgeSitesFact.Any(
                     ws => filters.WaterSourceTypes.Contains(ws.WaterSource.WaterSourceTypeCvNavigation.WaDEName))));
         }
+        
+        if (filters.BeneficialUses != null && filters.BeneficialUses.Count != 0)
+        {
+            query = query.Where(x => x.AllocationBridgeBeneficialUsesFact.Any(
+                bridge => filters.BeneficialUses.Contains(bridge.BeneficialUse.WaDEName)));
+        }
 
         if (!string.IsNullOrWhiteSpace(filters.LastKey))
         {

--- a/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
@@ -87,7 +87,7 @@ public class ApiV2Profile : Profile
             .ForMember(a => a.Organization, b => b.MapFrom(c => c.Organization.OrganizationName))
             .ForMember(a => a.VariableSpecificTypeCV, b => b.MapFrom(c => c.VariableSpecific.VariableSpecificCv))
             .ForMember(a => a.BeneficialUses,
-                b => b.MapFrom(c => c.AllocationBridgeBeneficialUsesFact.Select(d => d.BeneficialUseCV)))
+                b => b.MapFrom(c => c.AllocationBridgeBeneficialUsesFact.Select(d => d.BeneficialUse.WaDEName).Distinct()))
             .ForMember(a => a.DataPublicationDate, b => b.MapFrom(c => c.DataPublicationDate.Date))
             .ForMember(a => a.SitesUUIDs,
                 b => b.MapFrom(c => c.AllocationBridgeSitesFact.Select(d => d.Site.SiteUuid)))

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/RightFeaturesItemRequest.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/RightFeaturesItemRequest.cs
@@ -5,4 +5,5 @@ public class RightFeaturesItemRequest : RightFeaturesSearchRequestBase
     public string AllocationUuids { get; set; }
     public string SiteUuids { get; set; }
     public string WaterSourceTypes { get; set; }
+    public string BeneficialUses { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
@@ -100,6 +100,8 @@ public class OgcApiProfile : Profile
                 opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.AllocationUuids))
             .ForMember(dest => dest.WaterSourceTypes,
                 opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.WaterSourceTypes))
+            .ForMember(dest => dest.BeneficialUses,
+                opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.BeneficialUses))
             .ForMember(dest => dest.SiteUuid, opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.SiteUuids))
             .ForMember(dest => dest.LastKey, opt => opt.MapFrom(src => src.Next));
         
@@ -108,6 +110,7 @@ public class OgcApiProfile : Profile
             .ForMember(dest => dest.AllocationUuid, mem => mem.Ignore())
             .ForMember(dest => dest.SiteUuid, mem => mem.Ignore())
             .ForMember(dest => dest.WaterSourceTypes, mem => mem.Ignore())
+            .ForMember(dest => dest.BeneficialUses, mem => mem.Ignore())
             .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.LastKey, opt => opt.MapFrom(src => src.Next));
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/AllocationBridgeBeneficialUsesFactBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/AllocationBridgeBeneficialUsesFactBuilder.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using Bogus;
+using WesternStatesWater.WaDE.Accessors.EntityFramework;
+
+namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework;
+
+public static class AllocationBridgeBeneficialUsesFactBuilder
+{
+    public static AllocationBridgeBeneficialUsesFact Create()
+    {
+        return Create(new AllocationBridgeBeneficialUsesFactBuilderOptions());
+    }
+
+    public static AllocationBridgeBeneficialUsesFact Create(AllocationBridgeBeneficialUsesFactBuilderOptions opts)
+    {
+        var faker = new Faker<AllocationBridgeBeneficialUsesFact>()
+            .RuleFor(a => a.AllocationAmountId,
+                opts?.AllocationAmountsFact?.AllocationAmountId ?? AllocationAmountsFactBuilder.GenerateId())
+            .RuleFor(a => a.BeneficialUse, opts?.BeneficialUsesCv ?? BeneficalUsesBuilder.Create())
+            .RuleFor(a => a.BeneficialUseCV, (_, fact) => fact.BeneficialUse.WaDEName);
+
+        return faker;
+    }
+    
+    public static async Task<AllocationBridgeBeneficialUsesFact> Load(WaDEContext db)
+    {
+        return await Load(db, new AllocationBridgeBeneficialUsesFactBuilderOptions());
+    }
+    
+    public static async Task<AllocationBridgeBeneficialUsesFact> Load(WaDEContext db, AllocationBridgeBeneficialUsesFactBuilderOptions opts)
+    {
+        opts.AllocationAmountsFact ??= await AllocationAmountsFactBuilder.Load(db);
+        opts.BeneficialUsesCv ??= await BeneficalUsesBuilder.Load(db);
+        
+        var item = Create(opts);
+
+        db.AllocationBridgeBeneficialUsesFact.Add(item);
+        await db.SaveChangesAsync();
+
+        return item;
+    }
+}
+
+public class AllocationBridgeBeneficialUsesFactBuilderOptions
+{
+    public AllocationAmountsFact AllocationAmountsFact { get; set; }
+    public BeneficialUsesCV BeneficialUsesCv { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/BeneficalUsesBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/BeneficalUsesBuilder.cs
@@ -7,6 +7,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
     public static class BeneficalUsesBuilder
     {
         private static int _globalIndex = 0;
+
         public static BeneficialUsesCV Create()
         {
             return Create(new BeneficalUsesBuilderOptions());
@@ -16,6 +17,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         {
             return new Faker<BeneficialUsesCV>()
                 .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.WaDEName, f => opts?.WaDEName ?? f.Random.Words(3))
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())
@@ -36,16 +38,16 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 
             return item;
         }
-        
+
         public static string GenerateName()
         {
             _globalIndex++;
-            return CvNameGenerator.GetNextName(_globalIndex,50);
+            return CvNameGenerator.GetNextName(_globalIndex, 50);
         }
     }
 
     public class BeneficalUsesBuilderOptions
     {
-
+        public string WaDEName { get; set; }
     }
 }


### PR DESCRIPTION
Updated API Endpoint Water Rights Features Query to support `beneficialUses` query string parameter. Can send in one or more beneficial use and the response will include any water rights who has a the specified beneficial use. Fixed Water Right feature property `beneficialUses` not using WaDEName and ran distinct.