### PR TITLE
Filter Overlay Items by States, OverlayTypes or WaterSourceTypes

### DIFF
--- a/source/WaDEApiFunctions/v2/OverlaysFunction.cs
+++ b/source/WaDEApiFunctions/v2/OverlaysFunction.cs
@@ -64,6 +64,15 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
     [OpenApiParameter("overlayIds", Type = typeof(string[]), In = ParameterLocation.Query,
         Explode = false,
         Required = false, Description = "Comma separated list of overlay ids")]
+    [OpenApiParameter("states", Type = typeof(string[]), In = ParameterLocation.Query,
+        Explode = false,
+        Required = false, Description = "Comma separated list of state abbreviations")]
+    [OpenApiParameter("overlayTypes", Type = typeof(string[]), In = ParameterLocation.Query,
+        Explode = false,
+        Required = false, Description = "Comma separated list of overlay types")]
+    [OpenApiParameter("waterSourceTypes", Type = typeof(string[]), In = ParameterLocation.Query,
+        Explode = false,
+        Required = false, Description = "Comma separated list of water source types")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
         bodyType: typeof(Collection),
         Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
@@ -84,7 +93,10 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
             Limit = req.Query["limit"],
             Next = req.Query["next"],
             OverlayUuids = req.Query["overlayIds"],
-            SiteUuids = req.Query["siteIds"]
+            SiteUuids = req.Query["siteIds"],
+            States = req.Query["states"],
+            OverlayTypes = req.Query["overlayTypes"],
+            WaterSourceTypes = req.Query["waterSourceTypes"]
         };
         var response =
             await waterResourceManager.Search<OverlayFeaturesSearchRequestBase, OverlayFeaturesSearchResponse>(request);

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
@@ -19,5 +19,6 @@ public class OverlaySearchItem
     public string[] AreaNames { get; set; }
     public string[] AreaNativeIds { get; set; }
     public string[] SiteUuids { get; set; }
+    public string[] States { get; set; }
     public Geometry Areas { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/OverlaySearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/OverlaySearchRequest.cs
@@ -8,4 +8,7 @@ public class OverlaySearchRequest : SearchRequestBase
     public List<string> SiteUuids { get; set; }
     public SpatialSearchCriteria GeometrySearch { get; set; }
     public string LastKey { get; set; }
+    public List<string> States { get; set; }
+    public List<string> OverlayTypes { get; set; }
+    public List<string> WaterSourceTypes { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -134,6 +134,21 @@ public static class QueryableExtensions
                 _ => query
             };
         }
+        
+        if (filters.States != null && filters.States.Count != 0)
+        {
+            query = query.Where(o => o.RegulatoryReportingUnitsFact.Any(fact => filters.States.Contains(fact.ReportingUnit.StateCv)));
+        }
+        
+        if (filters.OverlayTypes != null && filters.OverlayTypes.Count != 0)
+        {
+            query = query.Where(o => filters.OverlayTypes.Contains(o.RegulatoryOverlayType.WaDEName));
+        }
+        
+        if (filters.WaterSourceTypes != null && filters.WaterSourceTypes.Count != 0)
+        {
+            query = query.Where(o => filters.WaterSourceTypes.Contains(o.WaterSourceType.WaDEName));
+        }
 
         if (!string.IsNullOrWhiteSpace(filters.LastKey))
         {

--- a/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
@@ -57,8 +57,8 @@ public class ApiV2Profile : Profile
             .ForMember(a => a.RegulatoryStatuteLink, b => b.MapFrom(c => c.RegulatoryStatuteLink))
             .ForMember(a => a.StatutoryEffectiveDate, b => b.MapFrom(c => c.StatutoryEffectiveDate))
             .ForMember(a => a.StatutoryEndDate, b => b.MapFrom(c => c.StatutoryEndDate))
-            .ForMember(a => a.OverlayType, b => b.MapFrom(c => c.RegulatoryOverlayTypeCV))
-            .ForMember(a => a.WaterSource, b => b.MapFrom(c => c.WaterSourceTypeCV))
+            .ForMember(a => a.OverlayType, b => b.MapFrom(c => c.RegulatoryOverlayType.WaDEName))
+            .ForMember(a => a.WaterSource, b => b.MapFrom(c => c.WaterSourceType.WaDEName))
             .ForMember(a => a.AreaNames,
                 b => b.MapFrom(c =>
                     c.RegulatoryReportingUnitsFact.Select(fact => fact.ReportingUnit.ReportingUnitName)))
@@ -69,7 +69,9 @@ public class ApiV2Profile : Profile
                 b => b.MapFrom(c => c.RegulatoryOverlayBridgeSitesFact.Select(fact => fact.Site.SiteUuid)))
             .ForMember(a => a.Areas,
                 b => b.MapFrom(c =>
-                    UnaryUnionOp.Union(c.RegulatoryReportingUnitsFact.Select(fact => fact.ReportingUnit.Geometry))));
+                    UnaryUnionOp.Union(c.RegulatoryReportingUnitsFact.Where(fact => fact.ReportingUnit.Geometry != null).Select(fact => fact.ReportingUnit.Geometry))))
+            .ForMember(a => a.States,
+                b => b.MapFrom(c => c.RegulatoryReportingUnitsFact.Select(fact => fact.ReportingUnit.StateCv).Distinct()));
 
         CreateMap<EF.AllocationAmountsFact, AllocationSearchItem>()
             .ForMember(a => a.AllocationApplicationDate,

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/OverlayFeaturesItemRequest.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/OverlayFeaturesItemRequest.cs
@@ -4,4 +4,7 @@ public class OverlayFeaturesItemRequest : OverlayFeaturesSearchRequestBase
 {    
     public string OverlayUuids { get; set; }
     public string SiteUuids { get; set; }
+    public string States { get; set; }
+    public string OverlayTypes { get; set; }
+    public string WaterSourceTypes { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Engines.Contracts/OverlayFeature.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/OverlayFeature.cs
@@ -32,5 +32,6 @@ public class OverlayFeature : FeatureBase
     public string[] AreaNativeIds { get; set; }
     [JsonPropertyName("sites")]
     public string[] SiteUuids { get; set; }
-
+    [JsonPropertyName("states")]
+    public string[] States { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
@@ -74,12 +74,19 @@ public class OgcApiProfile : Profile
                 mem => mem.ConvertUsing(new CommaStringToListConverter(), src => src.OverlayUuids))
             .ForMember(dest => dest.SiteUuids,
                 mem => mem.ConvertUsing(new CommaStringToListConverter(), src => src.SiteUuids))
+            .ForMember(dest => dest.States, mem => mem.ConvertUsing(new CommaStringToListConverter(), src => src.States))
+            .ForMember(dest => dest.WaterSourceTypes,
+                mem => mem.ConvertUsing(new CommaStringToListConverter(), src => src.WaterSourceTypes))
+            .ForMember(dest => dest.OverlayTypes, mem => mem.ConvertUsing(new CommaStringToListConverter(), src => src.OverlayTypes))
             .ForMember(dest => dest.LastKey, mem => mem.MapFrom(src => src.Next));
 
         CreateMap<Contracts.Api.Requests.V2.OverlayFeaturesAreaRequest,
                 Accessors.Contracts.Api.V2.Requests.OverlaySearchRequest>()
             .ForMember(dest => dest.OverlayUuids, mem => mem.Ignore())
             .ForMember(dest => dest.SiteUuids, mem => mem.Ignore())
+            .ForMember(dest => dest.States, mem => mem.Ignore())
+            .ForMember(dest => dest.WaterSourceTypes, mem => mem.Ignore())
+            .ForMember(dest => dest.OverlayTypes, mem => mem.Ignore())
             .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.LastKey, mem => mem.MapFrom(src => src.Next));
         

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/RegulatoryOverlayTypeBuilder.cs
@@ -16,6 +16,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         {
             return new Faker<RegulatoryOverlayType>()
                 .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.WaDEName, f => f.Random.Words(5))
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())


### PR DESCRIPTION
Updated the Overlay Items endpoint to support the following new query string parameters: `states`, `waterSourceTypes` and `overlayTypes`.

* Overlay feature properties now includes a distinct `states` list. States comes from the ReportingUnits table.
* `overlayType` feature property now uses WaDEName
* `waterSourceType` feature property now uses WaDEName