### PR TITLE
Filter Time Series by States, Variable Types, Water Source Types, or Primary Uses

### DIFF
--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/TimeSeriesSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/TimeSeriesSearchRequest.cs
@@ -8,5 +8,9 @@ public class TimeSeriesSearchRequest : SearchRequestBase
     public List<string> SiteUuids { get; set; }
     public DateTime? StartDate { get; set; }
     public DateTime? EndDate { get; set; }
+    public List<string> States { get; set; }
+    public List<string> VariableTypes { get; set; }
+    public List<string> PrimaryUses { get; set; }
+    public List<string> WaterSourceTypes { get; set; }
     public long? LastKey { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/TimeSeriesSearchItem.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/TimeSeriesSearchItem.cs
@@ -26,5 +26,8 @@ public class TimeSeriesSearchItem
     public string VariableSpecificUUID { get; set; }
     public string SiteUUID { get; set; }
     public string AssociatedNativeAllocationIDs { get; set; }
-    public List<string> BeneficialUses { get; set; }
+    public string PrimaryUse { get; set; }
+    public string State { get; set; }
+    public string VariableType { get; set; }
+    public WaterSourceSummary WaterSource { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -120,6 +120,21 @@ public static class QueryableExtensions
             query = query.Where(x => filters.SiteUuids.Contains(x.Site.SiteUuid));
         }
 
+        if (filters.States != null && filters.States.Count != 0)
+        {
+            query = query.Where(x => filters.States.Contains(x.Site.StateCv));
+        }
+
+        if (filters.VariableTypes != null && filters.VariableTypes.Count != 0)
+        {
+            query = query.Where(x => filters.VariableTypes.Contains(x.VariableSpecific.VariableCvNavigation.WaDEName));
+        }
+
+        if (filters.WaterSourceTypes != null && filters.WaterSourceTypes.Count != 0)
+        {
+            query = query.Where(x => filters.WaterSourceTypes.Contains(x.WaterSource.WaterSourceTypeCvNavigation.WaDEName));
+        }
+
         if (filters.LastKey.HasValue)
         {
             query = query.Where(x => x.SiteVariableAmountId > filters.LastKey);

--- a/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Mapping/ApiV2Profile.cs
@@ -120,7 +120,10 @@ public class ApiV2Profile : Profile
             .ForMember(a => a.VariableSpecificUUID, b => b.MapFrom(c => c.VariableSpecific.VariableSpecificUuid))
             .ForMember(a => a.SiteUUID, b => b.MapFrom(c => c.Site.SiteUuid))
             .ForMember(a => a.AssociatedNativeAllocationIDs, b => b.MapFrom(c => c.AssociatedNativeAllocationIds))
-            .ForMember(a => a.BeneficialUses,
-                b => b.MapFrom(c => c.SitesBridgeBeneficialUsesFact.Select(d => d.BeneficialUseCV)));
+            .ForMember(a => a.PrimaryUse,
+                b => b.MapFrom(c => c.PrimaryBeneficialUse.WaDEName))
+            .ForMember(a => a.State, b => b.MapFrom(c => c.Site.StateCv))
+            .ForMember(a => a.VariableType, b => b.MapFrom(c => c.VariableSpecific.VariableCvNavigation.WaDEName))
+            .ForMember(a => a.WaterSource, b => b.MapFrom(c => c.WaterSource));
     }
 }

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableBuilder.cs
@@ -16,6 +16,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         {
             return new Faker<Variable>()
                 .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.WaDEName, f => f.Random.Words(3))
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableSpecificBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/VariableSpecificBuilder.cs
@@ -16,6 +16,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         {
             return new Faker<VariableSpecific>()
                 .RuleFor(a => a.Name, f => GenerateName())
+                .RuleFor(a => a.WaDEName, f => f.Random.Words(3))
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
                 .RuleFor(a => a.State, f => f.Address.StateAbbr())


### PR DESCRIPTION
Updated TimeSeriesSearchHandler to support the following filters
* States[] - State abbreviations
* VariableTypes[] - CVs.Variable.WaDEName
* WaterSourcetypes[] - CVs.WaterSourceType.WaDEName
* PrimaryUses[] - CVs.BeneficialUses.WaDEName

Updated TimeSeriesSearchItem
* Renamed BeneficialUses to PrimaryUsse and made it a string because SiteVariableAmount to BeneficalUse is 1:1
* Added State which comes from the Sites_dim.StateCV
* Added VariableType which comes from the CVs.Variable.WaDEName
* Added WaterSource which comes from the WaterSources_dim