### PR TITLE
Rework TimeSeriesSearchHandler

### DIFF
--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Method.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Method.cs
@@ -1,0 +1,11 @@
+namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2;
+
+public class Method
+{
+    public string Uuid { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public string Type { get; set; }
+    public string NemiLink { get; set; }
+    public string ApplicableResourceType { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Organization.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Organization.cs
@@ -1,0 +1,12 @@
+namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2;
+
+public class Organization
+{
+    public string Uuid { get; set; }
+    public string Purview { get; set; }
+    public string Website { get; set; }
+    public string PhoneNumber { get; set; }
+    public string ContactName { get; set; }
+    public string ContactEmail { get; set; }
+    public string State { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/TimeSeriesSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/TimeSeriesSearchRequest.cs
@@ -12,5 +12,5 @@ public class TimeSeriesSearchRequest : SearchRequestBase
     public List<string> VariableTypes { get; set; }
     public List<string> PrimaryUses { get; set; }
     public List<string> WaterSourceTypes { get; set; }
-    public long? LastKey { get; set; }
+    public string LastKey { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Responses/TimeSeriesSearchResponse.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Responses/TimeSeriesSearchResponse.cs
@@ -4,5 +4,5 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Responses;
 
 public class TimeSeriesSearchResponse : SearchResponseBase
 {
-    public List<TimeSeriesSearchItem> TimeSeries { get; set; }
+    public List<TimeSeriesSearchItem> Sites { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Site.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Site.cs
@@ -1,0 +1,25 @@
+using NetTopologySuite.Geometries;
+
+namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2;
+
+public class Site
+{
+    public string SiteUuid { get; set; }
+    public string SiteNativeId { get; set; }
+    public string SiteName { get; set; }
+    public string UsgsSiteId { get; set; }
+    public string SiteType { get; set; }
+    public Geometry Location { get; set; }
+    public string CoordinateMethod { get; set; }
+    public string CoordinateAccuracy { get; set; }
+    public string GnisCode { get; set; }
+    public string EpsgCode { get; set; }
+    public string NhdNetworkStatus { get; set; }
+    public string NhdProduct { get; set; }
+    public string State { get; set; }
+    public string Huc8 { get; set; }
+    public string Huc12 { get; set; }
+    public string County { get; set; }
+    public string PodOrPouSite { get; set; }
+    public WaterSourceSummary[] WaterSources { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/SiteSearchItem.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/SiteSearchItem.cs
@@ -1,28 +1,3 @@
-using NetTopologySuite.Geometries;
-
 namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2;
 
-public class SiteSearchItem
-{
-    public string SiteUuid { get; set; }
-    public string SiteNativeId { get; set; }
-    public string SiteName { get; set; }
-    public string UsgsSiteId { get; set; }
-    public string SiteType { get; set; }
-    public Geometry Location { get; set; }
-    public string CoordinateMethod { get; set; }
-    public string CoordinateAccuracy { get; set; }
-    public string GnisCode { get; set; }
-    public string EpsgCode { get; set; }
-    public string NhdNetworkStatus { get; set; }
-    public string NhdProduct { get; set; }
-    public string State { get; set; }
-    public string Huc8 { get; set; }
-    public string Huc12 { get; set; }
-    public string County { get; set; }
-    public string[] RightUuids { get; set; }
-    public bool IsTimeSeries { get; set; }
-    public string PodOrPouSite { get; set; }
-    public WaterSourceSummary[] WaterSources { get; set; }
-    public string[] Overlays { get; set; }
-}
+public class SiteSearchItem : Site;

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/TimeSeries.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/TimeSeries.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2;
+
+public class TimeSeries
+{
+    public Organization Organization { get; set; }
+    public VariableSpecific VariableSpecific { get; set; }
+    public WaterSourceSummary WaterSource { get; set; }
+    public Method Method { get; set; }
+    public DateTime? TimeframeStart { get; set; }
+    public DateTime? TimeframeEnd { get; set; }
+    public string ReportYear { get; set; }
+    public double? Amount { get; set; }
+    public long? PopulationServed { get; set; }
+    public double? PowerGeneratedGWh { get; set; }
+    public double? IrrigatedAcreage { get; set; }
+    public string IrrigationMethod { get; set; }
+    public string CropType { get; set; }
+    public string CommunityWaterSupplySystem { get; set; }
+    public string SdwisIdentifier { get; set; }
+    public string AssociatedNativeAllocationIDs { get; set; } 
+    public string CustomerType { get; set; }
+    public double? AllocationCropDutyAmount { get; set; }
+    public string PrimaryUseCategory { get; set; }
+    public string PowerType { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/TimeSeriesSearchItem.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/TimeSeriesSearchItem.cs
@@ -1,33 +1,9 @@
-using System;
-using System.Collections.Generic;
-
 namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2;
 
-public class TimeSeriesSearchItem
+/// <summary>
+/// A Site that has Time Series associated with it.
+/// </summary>
+public class TimeSeriesSearchItem : Site
 {
-    public long SiteVariableAmountId { get; set; }
-    public string WaterSourceUUID { get; set; }
-    public string AllocationGNISIDCV { get; set; }
-    public DateTime? TimeframeStart { get; set; }
-    public DateTime? TimeframeEnd { get; set; }
-    public DateTime? DataPublicationDate { get; set; }
-    public double? AllocationCropDutyAmount { get; set; }
-    public double? Amount { get; set; }
-    public string IrrigationMethodCV { get; set; }
-    public double? IrrigatedAcreage { get; set; }
-    public string CropTypeCV { get; set; }
-    public long? PopulationServed { get; set; }
-    public double? PowerGeneratedGWh { get; set; }
-    public string AllocationCommunityWaterSupplySystem { get; set; }
-    public string SDWISIdentifier { get; set; }
-    public string DataPublicationDOI { get; set; }
-    public string ReportYearCV { get; set; }
-    public string MethodUUID { get; set; }
-    public string VariableSpecificUUID { get; set; }
-    public string SiteUUID { get; set; }
-    public string AssociatedNativeAllocationIDs { get; set; }
-    public string PrimaryUse { get; set; }
-    public string State { get; set; }
-    public string VariableType { get; set; }
-    public WaterSourceSummary WaterSource { get; set; }
+   public TimeSeries[] TimeSeries { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/VariableSpecific.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/VariableSpecific.cs
@@ -1,0 +1,15 @@
+namespace WesternStatesWater.WaDE.Accessors.Contracts.Api.V2;
+
+public class VariableSpecific
+{
+    public string Uuid { get; set; }
+    public string Name { get; set; }
+    public string Variable { get; set; }
+    public string AggregationStatistic { get; set; }
+    public string AggregationInterval { get; set; }
+    public string AggregationIntervalUnit { get; set; }
+    public string ReportYearStartMonth { get; set; }
+    public string ReportYearType { get; set; }
+    public string AmountUnit { get; set; }
+    public string MaximumAmountUnit { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -111,48 +111,57 @@ public static class QueryableExtensions
         return query;
     }
 
-    public static IQueryable<SiteVariableAmountsFact> ApplySearchFilters(this IQueryable<SiteVariableAmountsFact> query,
+    public static IQueryable<SitesDim> ApplySearchFilters(this IQueryable<SitesDim> query,
         TimeSeriesSearchRequest filters)
     {
+        // Only include sites with time series data
+        query = query.Where(x => x.SiteVariableAmountsFact.Count != 0);
+        
         if (filters.StartDate.HasValue)
         {
             query = query.Where(x =>
-                (filters.StartDate >= x.TimeframeStartNavigation.Date &&
-                 filters.StartDate <= x.TimeframeEndNavigation.Date) ||
-                filters.StartDate <= x.TimeframeStartNavigation.Date);
+                x.SiteVariableAmountsFact.Any(ts =>
+                    // Check if filtered start date is within the time series date range
+                    (filters.StartDate >= ts.TimeframeStartNavigation.Date &&
+                     filters.StartDate <= ts.TimeframeEndNavigation.Date) ||
+                    // Else check if filtered start date is before the time series start date
+                    filters.StartDate <= ts.TimeframeStartNavigation.Date));
         }
 
         if (filters.EndDate.HasValue)
         {
             query = query.Where(x =>
-                (filters.EndDate >= x.TimeframeStartNavigation.Date &&
-                 filters.EndDate <= x.TimeframeEndNavigation.Date) ||
-                x.TimeframeEndNavigation.Date <= filters.EndDate);
+                x.SiteVariableAmountsFact.Any(ts =>
+                    // Check if filtered end date is within the time series date range
+                    (filters.EndDate >= ts.TimeframeStartNavigation.Date &&
+                     filters.EndDate <= ts.TimeframeEndNavigation.Date) ||
+                    // Else check if filtered end date is after the time series end date
+                    ts.TimeframeEndNavigation.Date <= filters.EndDate));
         }
 
         if (filters.SiteUuids != null && filters.SiteUuids.Count != 0)
         {
-            query = query.Where(x => filters.SiteUuids.Contains(x.Site.SiteUuid));
+            query = query.Where(x => filters.SiteUuids.Contains(x.SiteUuid));
         }
 
         if (filters.States != null && filters.States.Count != 0)
         {
-            query = query.Where(x => filters.States.Contains(x.Site.StateCv));
+            query = query.Where(x => filters.States.Contains(x.StateCv));
         }
 
         if (filters.VariableTypes != null && filters.VariableTypes.Count != 0)
         {
-            query = query.Where(x => filters.VariableTypes.Contains(x.VariableSpecific.VariableCvNavigation.WaDEName));
+            query = query.Where(x => x.SiteVariableAmountsFact.Any(ts => filters.VariableTypes.Contains(ts.VariableSpecific.VariableCvNavigation.WaDEName)));
         }
 
         if (filters.WaterSourceTypes != null && filters.WaterSourceTypes.Count != 0)
         {
-            query = query.Where(x => filters.WaterSourceTypes.Contains(x.WaterSource.WaterSourceTypeCvNavigation.WaDEName));
+            query = query.Where(x => x.SiteVariableAmountsFact.Any(ts => filters.WaterSourceTypes.Contains(ts.WaterSource.WaterSourceTypeCvNavigation.WaDEName)));
         }
 
-        if (filters.LastKey.HasValue)
+        if (!string.IsNullOrWhiteSpace(filters.LastKey))
         {
-            query = query.Where(x => x.SiteVariableAmountId > filters.LastKey);
+            query = query.Where(x => x.SiteUuid.CompareTo(filters.LastKey) > 0);
         }
 
         return query;

--- a/source/WesternStatesWater.WaDE.Accessors/Handlers/TimeSeriesSearchHandler.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Handlers/TimeSeriesSearchHandler.cs
@@ -20,18 +20,27 @@ public class TimeSeriesSearchHandler(IConfiguration configuration)
     {
         await using var db = new WaDEContext(configuration);
 
-        var timeSeries = await db.SiteVariableAmountsFact
+        var sites = await db.SitesDim
             .AsNoTracking()
-            .OrderBy(ts => ts.SiteVariableAmountId)
+            .OrderBy(sd => sd.SiteUuid)
             .ApplySearchFilters(request)
             .ApplyLimit(request)
             .ProjectTo<TimeSeriesSearchItem>(DtoMapper.Configuration)
             .ToListAsync();
             
+        string lastUuid = null;
+        // Only set lastUuid if more than one item was returned.
+        // Requests looking up a specific record will only have count of 1 or 0.
+        if (sites.Count > 1)
+        {
+            // Get the last UUID of the page (not the first one on the next page).
+            lastUuid = sites.Count <= request.Limit ? null : sites[^2].SiteUuid;    
+        }
+        
         return new TimeSeriesSearchResponse
         {
-            LastUuid = timeSeries.Count <= request.Limit ? null : timeSeries[^1].SiteVariableAmountId.ToString(),
-            TimeSeries = timeSeries.Take(request.Limit).ToList()
+            LastUuid = lastUuid,
+            Sites = sites.Take(request.Limit).ToList()
         };
     }
 }

--- a/source/WesternStatesWater.WaDE.Engines.Contracts/SiteFeature.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/SiteFeature.cs
@@ -32,14 +32,8 @@ public class SiteFeature : FeatureBase
     public string? Huc12 { get; set; }
     [JsonPropertyName("county")]
     public string? County { get; set; }
-    [JsonPropertyName("rightUuids")]
-    public string[]? RightUuids { get; set; }
-    [JsonPropertyName("isTimeSeries")]
-    public bool? IsTimeSeries { get; set; }
     [JsonPropertyName("podOrPouSite")]
     public string? PodOrPouSite { get; set; }
     [JsonPropertyName("waterSources")]
     public WaterSourceSummary[]? WaterSources { get; set; }
-    [JsonPropertyName("overlays")]
-    public string[]? Overlays { get; set; }
 }


### PR DESCRIPTION
Originally I assumed Time Series API endpoints would return SiteVariableAmountsFact data. This assumption was only partly true. Ryan James at WaDE wants the Time Series API to return sites with time series information. In order to accommodate this, I moved the `SiteSearchItem` properties into a `V2.Site` that can be shared by `SiteSearchItem` and `TimeSeriesItem`. `TimeSeriesItem` will additionally have a `TimeSeries[]` to list all the site variable amounts for that given site.

Example request.
`GET` `/collections/timeseries/items?state=NE`
Expected Response
```
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "coordinates": [[..]],
        "type": "Point",
        "properties": {
          "SiteUUID": "NE_123",
          << other site properties >>
          "TimeSeries": [ .. ]
        }
      }
    }
  ]
}
```