### PR TITLE
API V2 Updates

### DIFF
--- a/source/WaDEApiFunctions/Program.cs
+++ b/source/WaDEApiFunctions/Program.cs
@@ -1,11 +1,7 @@
 using System;
-using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.OpenApi.Models;
 using WaDEApiFunctions;
 using WesternStatesWater.WaDE.Accessors;
 using WesternStatesWater.WaDE.Accessors.Handlers;
@@ -24,7 +20,6 @@ using ManagerExt = WesternStatesWater.WaDE.Managers.Api.Extensions;
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication(builder =>
     {
-        builder.UseNewtonsoftJson();
         builder.UseMiddleware<HttpContextAccessorMiddleware>();
     })
     .ConfigureAppConfiguration((_, configBuilder) =>
@@ -43,28 +38,7 @@ var host = new HostBuilder()
     {
         var configuration = context.Configuration;
 
-        services.AddSingleton<IOpenApiConfigurationOptions>(_ =>
-        {
-            var options = new OpenApiConfigurationOptions()
-            {
-                Info = new OpenApiInfo()
-                {
-                    Version = DefaultOpenApiConfigurationOptions.GetOpenApiDocVersion(),
-                    Title = DefaultOpenApiConfigurationOptions.GetOpenApiDocTitle(),
-                    Description = DefaultOpenApiConfigurationOptions.GetOpenApiDocDescription()
-                },
-                Servers = DefaultOpenApiConfigurationOptions.GetHostNames(),
-                OpenApiVersion = DefaultOpenApiConfigurationOptions.GetOpenApiVersion(),
-                IncludeRequestingHostName =
-                    DefaultOpenApiConfigurationOptions.IsFunctionsRuntimeEnvironmentDevelopment(),
-                ForceHttps = DefaultOpenApiConfigurationOptions.IsHttpsForced(),
-                ForceHttp = DefaultOpenApiConfigurationOptions.IsHttpForced(),
-            };
-
-            return options;
-        });
-
-        services.AddHttpContextAccessor();
+       services.AddHttpContextAccessor();
         services.AddSingleton(configuration);
 
         services.AddScoped<

--- a/source/WaDEApiFunctions/WaDEApiFunctions.csproj
+++ b/source/WaDEApiFunctions/WaDEApiFunctions.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.5.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />

--- a/source/WaDEApiFunctions/local.settings.json
+++ b/source/WaDEApiFunctions/local.settings.json
@@ -11,7 +11,9 @@
     "OpenApi__ForceHttp": "true",
     "OgcApi__Title": "WaDE OGC API",
     "OgcApi__Description": "WaDE 2.0 OGC API",
-    "OgcApi__Host": "http://localhost:7071/api/v2"
+    "OgcApi__Host": "http://localhost:7071/api/v2",
+    "OgcApi__SwaggerDoc": "http://localhost:7071/api/swagger/ui",
+    "OgcApi__SwaggerDescription": "http://localhost:7071/api/swagger.json"
   },
   "ConnectionStrings": {
     "AzureStorage": "UseDevelopmentStorage=true",

--- a/source/WaDEApiFunctions/v2/DiscoverabilityFunction.cs
+++ b/source/WaDEApiFunctions/v2/DiscoverabilityFunction.cs
@@ -1,11 +1,7 @@
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using WesternStatesWater.WaDE.Contracts.Api;
-using WesternStatesWater.WaDE.Contracts.Api.OgcApi;
 using WesternStatesWater.WaDE.Contracts.Api.Requests.V2;
 using WesternStatesWater.WaDE.Contracts.Api.Responses.V2;
 
@@ -23,11 +19,6 @@ public class DiscoverabilityFunction : FunctionBase
     }
 
     [Function("LandingPage")]
-    [OpenApiOperation(operationId: "getLandingPage", tags: ["Capabilities"], Summary = "Landing Page",
-        Description = "The landing page provides links to the API definition.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(DiscoveryMetadataGetResponse),
-        Summary = "The response", Description = "The operation was executed successfully.")]
     public async Task<HttpResponseData> LandingPage(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase)]
         HttpRequestData req,
@@ -36,17 +27,10 @@ public class DiscoverabilityFunction : FunctionBase
         var request = new DiscoveryMetadataGetRequest();
         var response = await _metadataManager.Load<DiscoveryMetadataGetRequest, DiscoveryMetadataGetResponse>(request);
 
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
 
     [Function("Conformance")]
-    [OpenApiOperation(operationId: "getConformance", tags: ["Capabilities"], Summary = "Conformance",
-        Description = "Conformance declaration for the OGC API.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(ConformanceMetadataGetResponse),
-        Summary = "The URIs of all conformance classes supported by the server.",
-        Description = "The operation was executed successfully.")]
     public async Task<HttpResponseData> Conformance(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "conformance")]
         HttpRequestData req,
@@ -54,16 +38,10 @@ public class DiscoverabilityFunction : FunctionBase
     {
         var request = new ConformanceMetadataGetRequest();
         var response = await _metadataManager.Load<ConformanceMetadataGetRequest, ConformanceMetadataGetResponse>(request);
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
 
     [Function("Collections")]
-    [OpenApiOperation(operationId: "getCollections", tags: ["Discovery"], Summary = "Discovery",
-        Description = "Collections",
-        Visibility = OpenApiVisibilityType.Advanced)]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(CollectionsMetadataGetResponse),
-        Summary = "WaDE Collections", Description = "The operation was executed successfully.")]
     public async Task<HttpResponseData> Collections(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "collections")]
         HttpRequestData req,
@@ -74,6 +52,6 @@ public class DiscoverabilityFunction : FunctionBase
         var response = await _metadataManager
             .Load<CollectionsMetadataGetRequest, CollectionsMetadataGetResponse>(request);
         
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
 }

--- a/source/WaDEApiFunctions/v2/OverlaysFunction.cs
+++ b/source/WaDEApiFunctions/v2/OverlaysFunction.cs
@@ -30,6 +30,7 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
         HttpRequestData req,
         FunctionContext executionContext)
     {
+        // Modifying any query string parameters, will require updating swagger.json.
         var request = new OverlayFeaturesItemRequest
         {
             Bbox = req.Query["bbox"],
@@ -53,6 +54,7 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
         HttpRequestData req,
         FunctionContext executionContext)
     {
+        // Modifying any query string parameters, will require updating swagger.json.
         var request = new OverlayFeaturesAreaRequest
         {
             Coords = req.Query["coords"],

--- a/source/WaDEApiFunctions/v2/OverlaysFunction.cs
+++ b/source/WaDEApiFunctions/v2/OverlaysFunction.cs
@@ -1,11 +1,6 @@
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
-using Microsoft.OpenApi.Models;
-using WesternStatesWater.WaDE.Common.Ogc;
 using WesternStatesWater.WaDE.Contracts.Api;
 using WesternStatesWater.WaDE.Contracts.Api.Requests;
 using WesternStatesWater.WaDE.Contracts.Api.Requests.V2;
@@ -16,21 +11,8 @@ namespace WaDEApiFunctions.v2;
 public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceManager waterResourceManager) : FunctionBase
 {
     private const string PathBase = "v2/collections/overlays/";
-    private const string Tag = "Overlays";
 
     [Function(nameof(GetOverlaysCollectionMetadata))]
-    [OpenApiOperation(operationId: "getOverlaysCollections", tags: [Tag], Summary = "Overlays collection metadata",
-        Description = "WaDE overlays collection.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "Successful request", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetOverlaysCollectionMetadata(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase)]
         HttpRequestData req,
@@ -39,46 +21,10 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateOkResponse(req, response.Collection);
+        return await CreateResponse(req, response);
     }
 
     [Function(nameof(GetOverlays))]
-    [OpenApiOperation(operationId: "getOverlays", tags: [Tag], Summary = "Get overlay collection items",
-        Description = "List of overlays.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiParameter("limit", Type = typeof(int), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "The maximum number of items to return.")]
-    [OpenApiParameter("bbox", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Bounding box to filter results.")]
-    [OpenApiParameter("next", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Next page")]
-    [OpenApiParameter("siteIds", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Comma separated list of site ids")]
-    [OpenApiParameter("overlayIds", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Comma separated list of overlay ids")]
-    [OpenApiParameter("states", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Comma separated list of state abbreviations")]
-    [OpenApiParameter("overlayTypes", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Comma separated list of overlay types")]
-    [OpenApiParameter("waterSourceTypes", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Comma separated list of water source types")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetOverlays(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "items")]
         HttpRequestData req,
@@ -98,31 +44,10 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
         var response =
             await waterResourceManager.Search<OverlayFeaturesSearchRequestBase, OverlayFeaturesSearchResponse>(request);
 
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
     
     [Function(nameof(GetOverlaysInArea))]
-    [OpenApiOperation(operationId: "getOverlaysInArea", tags: [Tag], Summary = "Get overlay collection items in the given area",
-        Description = "List of overlays.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiParameter("limit", Type = typeof(int), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "The maximum number of items to return.")]
-    [OpenApiParameter("coords", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Only data that has a geometry that intersects the area defined by the polygon are selected.\n\nThe polygon is defined using a Well Known Text string following\n\ncoords=POLYGON((x y,x1 y1,x2 y2,...,xn yn x y)).")]
-    [OpenApiParameter("next", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Next page")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetOverlaysInArea(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "area")]
         HttpRequestData req,
@@ -137,24 +62,10 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
         var response =
             await waterResourceManager.Search<OverlayFeaturesSearchRequestBase, OverlayFeaturesSearchResponse>(request);
 
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
     
     [Function(nameof(GetOverlay))]
-    [OpenApiOperation(operationId: "getOverlay", tags: [Tag], Summary = "Get a overlay feature",
-        Description = "TODO: feature.",
-        Visibility = OpenApiVisibilityType.Internal)]
-    [OpenApiParameter("featureId", Type = typeof(string), In = ParameterLocation.Path,
-        Required = true, Description = "The identifier of the feature.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetOverlay(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "items/{featureId}")]
         HttpRequestData req,
@@ -168,6 +79,6 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
         };
         var response = await waterResourceManager.Search<OverlayFeatureItemGetRequest, OverlayFeatureItemGetResponse>(request);
     
-        return await CreateOkResponse(req, response.Feature);
+        return await CreateResponse(req, response);
     }
 }

--- a/source/WaDEApiFunctions/v2/RightsFunction.cs
+++ b/source/WaDEApiFunctions/v2/RightsFunction.cs
@@ -30,6 +30,7 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
         HttpRequestData req,
         FunctionContext executionContext)
     {
+        // Modifying any query string parameters, will require updating swagger.json.
         var request = new RightFeaturesItemRequest
         {
             Bbox = req.Query["bbox"],
@@ -52,6 +53,7 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
         HttpRequestData req,
         FunctionContext executionContext)
     {
+        // Modifying any query string parameters, will require updating swagger.json.
         var request = new RightFeaturesAreaRequest
         {
             Coords = req.Query["coords"],

--- a/source/WaDEApiFunctions/v2/RightsFunction.cs
+++ b/source/WaDEApiFunctions/v2/RightsFunction.cs
@@ -1,11 +1,6 @@
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
-using Microsoft.OpenApi.Models;
-using WesternStatesWater.WaDE.Common.Ogc;
 using WesternStatesWater.WaDE.Contracts.Api;
 using WesternStatesWater.WaDE.Contracts.Api.Requests;
 using WesternStatesWater.WaDE.Contracts.Api.Requests.V2;
@@ -16,21 +11,8 @@ namespace WaDEApiFunctions.v2;
 public class RightsFunction(IMetadataManager metadataManager, IWaterResourceManager waterResourceManager) : FunctionBase
 {
     private const string PathBase = "v2/collections/rights";
-    private const string Tag = "Rights";
 
     [Function(nameof(GetRightsCollectionMetadata))]
-    [OpenApiOperation(operationId: "getRightsCollection", tags: [Tag], Summary = "Rights collection metadata",
-        Description = "WaDE water rights collection",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "Successful request", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetRightsCollectionMetadata(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase)]
         HttpRequestData req,
@@ -39,46 +21,10 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateOkResponse(req, response.Collection);
+        return await CreateResponse(req, response);
     }
 
     [Function(nameof(GetRights))]
-    [OpenApiOperation(operationId: "getRights", tags: [Tag], Summary = "Get water right collection items",
-        Description = "Allocations",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiParameter("limit", Type = typeof(int), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "The maximum number of items to return.")]
-    [OpenApiParameter("bbox", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Bounding box to filter results.")]
-    [OpenApiParameter("next", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Next page")]
-    [OpenApiParameter("allocationUuids", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Allocation UUIDs")]
-    [OpenApiParameter("siteUuids", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Site UUIDs")]
-    [OpenApiParameter("states", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "State abbreviations")]
-    [OpenApiParameter("waterSourceTypes", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Water Source Types")]
-    [OpenApiParameter("beneficialUses", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Beneficial Uses")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetRights(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "/items")]
         HttpRequestData req,
@@ -97,31 +43,10 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
         };
         var response = await waterResourceManager.Search<RightFeaturesSearchRequestBase, RightFeaturesSearchResponse>(request);
         
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
     
     [Function(nameof(GetRightsInArea))]
-    [OpenApiOperation(operationId: "getRightsInArea", tags: [Tag], Summary = "Get water right for a given area",
-        Description = "Allocations",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiParameter("limit", Type = typeof(int), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "The maximum number of items to return.")]
-    [OpenApiParameter("coords", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Only data that has a geometry that intersects the area defined by the polygon are selected.\n\nThe polygon is defined using a Well Known Text string following\n\ncoords=POLYGON((x y,x1 y1,x2 y2,...,xn yn x y)).")]
-    [OpenApiParameter("next", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Next page")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetRightsInArea(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "/area")]
         HttpRequestData req,
@@ -135,24 +60,10 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
         };
         var response = await waterResourceManager.Search<RightFeaturesSearchRequestBase, RightFeaturesSearchResponse>(request);
         
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
     
     [Function(nameof(GetWaterRight))]
-    [OpenApiOperation(operationId: "getWaterRight", tags: [Tag], Summary = "Get a water right feature",
-        Description = "TODO: feature.",
-        Visibility = OpenApiVisibilityType.Internal)]
-    [OpenApiParameter("featureId", Type = typeof(string), In = ParameterLocation.Path,
-        Required = true, Description = "The identifier of the feature.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetWaterRight(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "/items/{featureId}")]
         HttpRequestData req,
@@ -166,6 +77,6 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
         };
         var response = await waterResourceManager.Search<RightFeatureItemGetRequest, RightFeatureItemGetResponse>(request);
     
-        return await CreateOkResponse(req, response.Feature);
+        return await CreateResponse(req, response);
     }
 }

--- a/source/WaDEApiFunctions/v2/SitesFunction.cs
+++ b/source/WaDEApiFunctions/v2/SitesFunction.cs
@@ -32,6 +32,7 @@ public class WaterSitesFunction(
         HttpRequestData req,
         FunctionContext executionContext)
     {
+        // Modifying any query string parameters, will require updating swagger.json.
         var request = new SiteFeaturesItemRequest
         {
             Bbox = req.Query["bbox"],
@@ -53,6 +54,7 @@ public class WaterSitesFunction(
         HttpRequestData req,
         FunctionContext executionContext)
     {
+        // Modifying any query string parameters, will require updating swagger.json.
         var request = new SiteFeaturesAreaRequest
         {
             Coords = req.Query["coords"],

--- a/source/WaDEApiFunctions/v2/SitesFunction.cs
+++ b/source/WaDEApiFunctions/v2/SitesFunction.cs
@@ -1,11 +1,6 @@
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
-using Microsoft.OpenApi.Models;
-using WesternStatesWater.WaDE.Common.Ogc;
 using WesternStatesWater.WaDE.Contracts.Api;
 using WesternStatesWater.WaDE.Contracts.Api.Requests;
 using WesternStatesWater.WaDE.Contracts.Api.Requests.V2;
@@ -18,22 +13,8 @@ public class WaterSitesFunction(
     IWaterResourceManager waterResourceManager) : FunctionBase
 {
     private const string PathBase = "v2/collections/sites/";
-
-    private const string Tag = "Sites";
-
+    
     [Function(nameof(GetSiteCollectionMetadata))]
-    [OpenApiOperation(operationId: "getSiteCollection", tags: [Tag], Summary = "Site collection metadata",
-        Description = "WaDE sites collection.",
-        Visibility = OpenApiVisibilityType.Internal)]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "Successful request", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetSiteCollectionMetadata(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase)]
         HttpRequestData req,
@@ -42,40 +23,10 @@ public class WaterSitesFunction(
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateOkResponse(req, response.Collection);
+        return await CreateResponse(req, response);
     }
 
     [Function(nameof(GetWaterSites))]
-    [OpenApiOperation(operationId: "getWaterSites", tags: [Tag], Summary = "Get water site collection items",
-        Description = "TODO: features of site.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiParameter("limit", Type = typeof(int), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "The maximum number of items to return.")]
-    [OpenApiParameter("bbox", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Bounding box to filter results.")]
-    [OpenApiParameter("next", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Next page")]
-    [OpenApiParameter("siteTypes", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Site Types")]
-    [OpenApiParameter("states", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "State abbreviations")]
-    [OpenApiParameter("waterSourceTypes", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Water Source Types")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetWaterSites(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "items")]
         HttpRequestData req,
@@ -93,43 +44,10 @@ public class WaterSitesFunction(
         var response =
             await waterResourceManager.Search<SiteFeaturesSearchRequestBase, SiteFeaturesSearchResponse>(request);
 
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
 
     [Function(nameof(GetWaterSitesInArea))]
-    [OpenApiOperation(operationId: "getWaterSitesInArea", tags: [Tag],
-        Summary = "Return the data values for the data area defined by the query parameters",
-        Description = "TODO: features of site.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiParameter("limit", Type = typeof(int), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "The maximum number of items to return.")]
-    [OpenApiParameter("coords", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false,
-        Description =
-            "Only data that has a geometry that intersects the area defined by the polygon are selected.\n\nThe polygon is defined using a Well Known Text string following\n\ncoords=POLYGON((x y,x1 y1,x2 y2,...,xn yn x y)).")]
-    [OpenApiParameter("next", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Next page")]
-    [OpenApiParameter("siteUuids", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Comma separated list of site Uuids")]
-    [OpenApiParameter("overlayUuids", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Comma separated list of overlay Uuids")]
-    [OpenApiParameter("allocationUuids", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Comma separated list of allocation Uuids")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetWaterSitesInArea(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "area")]
         HttpRequestData req,
@@ -144,24 +62,10 @@ public class WaterSitesFunction(
         var response =
             await waterResourceManager.Search<SiteFeaturesSearchRequestBase, SiteFeaturesSearchResponse>(request);
 
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
 
     [Function(nameof(GetWaterSite))]
-    [OpenApiOperation(operationId: "getWaterSite", tags: [Tag], Summary = "Get a water site feature W",
-        Description = "TODO: feature.",
-        Visibility = OpenApiVisibilityType.Internal)]
-    [OpenApiParameter("featureId", Type = typeof(string), In = ParameterLocation.Path,
-        Required = true, Description = "The identifier of the feature.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetWaterSite(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "items/{featureId}")]
         HttpRequestData req,
@@ -175,6 +79,6 @@ public class WaterSitesFunction(
         };
         var response = await waterResourceManager.Search<SiteFeatureItemGetRequest, SiteFeatureItemGetResponse>(request);
 
-        return await CreateOkResponse(req, response.Feature);
+        return await CreateResponse(req, response);
     }
 }

--- a/source/WaDEApiFunctions/v2/TimeSeriesFunction.cs
+++ b/source/WaDEApiFunctions/v2/TimeSeriesFunction.cs
@@ -1,11 +1,6 @@
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
-using Microsoft.OpenApi.Models;
-using WesternStatesWater.WaDE.Common.Ogc;
 using WesternStatesWater.WaDE.Contracts.Api;
 using WesternStatesWater.WaDE.Contracts.Api.Requests;
 using WesternStatesWater.WaDE.Contracts.Api.Requests.V2;
@@ -17,21 +12,8 @@ public class TimeSeriesFunction(IMetadataManager metadataManager, IWaterResource
     : FunctionBase
 {
     private const string PathBase = "v2/collections/timeSeries/";
-    private const string Tag = "Time Series";
 
     [Function(nameof(GetTimeSeriesCollectionMetadata))]
-    [OpenApiOperation(operationId: "getTimeSeriesCollections", tags: [Tag], Summary = "Time Series collection metadata",
-        Description = "WaDE time series collection.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "Successful request", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetTimeSeriesCollectionMetadata(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase)]
         HttpRequestData req,
@@ -40,46 +22,10 @@ public class TimeSeriesFunction(IMetadataManager metadataManager, IWaterResource
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateOkResponse(req, response.Collection);
+        return await CreateResponse(req, response);
     }
 
     [Function(nameof(SearchTimeSeries))]
-    [OpenApiOperation(operationId: "searchTimeSeries", tags: [Tag], Summary = "Get time series collection items",
-        Description = "TODO: features of site.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiParameter("limit", Type = typeof(int), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "The maximum number of items to return.")]
-    [OpenApiParameter("bbox", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Bounding box to filter results.")]
-    [OpenApiParameter("next", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Next page")]
-    [OpenApiParameter("siteUuids", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Comma separate list of Site UUIDs")]
-    [OpenApiParameter("states", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "State abbreviations")]
-    [OpenApiParameter("waterSourceTypes", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Water Source Types")]
-    [OpenApiParameter("variableTypes", Type = typeof(string[]), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Variable Types")]
-    [OpenApiParameter("datetime", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Date time")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> SearchTimeSeries(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "items")]
         HttpRequestData req,
@@ -99,34 +45,10 @@ public class TimeSeriesFunction(IMetadataManager metadataManager, IWaterResource
         var response =
             await waterResourceManager.Search<TimeSeriesFeaturesSearchRequestBase, TimeSeriesFeaturesSearchResponse>(request);
 
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
 
     [Function(nameof(SearchTimeSeriesInArea))]
-    [OpenApiOperation(operationId: "searchTimeSeriesInArea", tags: [Tag],
-        Summary = "Get time series collection items in area.",
-        Description = "TODO: features of site.",
-        Visibility = OpenApiVisibilityType.Important)]
-    [OpenApiParameter("limit", Type = typeof(int), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "The maximum number of items to return.")]
-    [OpenApiParameter("coords", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false,
-        Description =
-            "Only data that has a geometry that intersects the area defined by the polygon are selected.\n\nThe polygon is defined using a Well Known Text string following\n\ncoords=POLYGON((x y,x1 y1,x2 y2,...,xn yn x y)).")]
-    [OpenApiParameter("next", Type = typeof(string), In = ParameterLocation.Query,
-        Explode = false,
-        Required = false, Description = "Next page")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(Collection),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> SearchTimeSeriesInArea(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "area")]
         HttpRequestData req,
@@ -141,24 +63,10 @@ public class TimeSeriesFunction(IMetadataManager metadataManager, IWaterResource
         var response =
             await waterResourceManager.Search<TimeSeriesFeaturesSearchRequestBase, TimeSeriesFeaturesSearchResponse>(request);
 
-        return await CreateOkResponse(req, response);
+        return await CreateResponse(req, response);
     }
     
     [Function(nameof(GetTimeSeries))]
-    [OpenApiOperation(operationId: "getTimeSeries", tags: [Tag], Summary = "Get a site time series",
-        Description = "TODO: feature.",
-        Visibility = OpenApiVisibilityType.Internal)]
-    [OpenApiParameter("featureId", Type = typeof(string), In = ParameterLocation.Path,
-        Required = true, Description = "The identifier of the feature.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "TODO: summary of collection.", Description = "The operation was executed successfully.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Bad request", Description = "The request was invalid.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json",
-        bodyType: typeof(object),
-        Summary = "Not found", Description = "The request was invalid.")]
     public async Task<HttpResponseData> GetTimeSeries(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = PathBase + "items/{featureId}")]
         HttpRequestData req,
@@ -172,6 +80,6 @@ public class TimeSeriesFunction(IMetadataManager metadataManager, IWaterResource
         };
         var response = await waterResourceManager.Search<TimeSeriesFeatureItemGetRequest, TimeSeriesFeatureItemGetResponse>(request);
 
-        return await CreateOkResponse(req, response.Feature);
+        return await CreateResponse(req, response);
     }
 }

--- a/source/WaDEApiFunctions/v2/TimeSeriesFunction.cs
+++ b/source/WaDEApiFunctions/v2/TimeSeriesFunction.cs
@@ -31,6 +31,7 @@ public class TimeSeriesFunction(IMetadataManager metadataManager, IWaterResource
         HttpRequestData req,
         FunctionContext executionContext)
     {
+        // Modifying any query string parameters, will require updating swagger.json.
         var request = new TimeSeriesFeaturesItemRequest
         {
             Bbox = req.Query["bbox"],
@@ -54,6 +55,7 @@ public class TimeSeriesFunction(IMetadataManager metadataManager, IWaterResource
         HttpRequestData req,
         FunctionContext executionContext)
     {
+        // Modifying any query string parameters, will require updating swagger.json.
         var request = new TimeSeriesFeaturesAreaRequest()
         {
             Coords = req.Query["coords"],

--- a/source/WaDEApiFunctions/v2/swagger.json
+++ b/source/WaDEApiFunctions/v2/swagger.json
@@ -6,9 +6,9 @@
     "version": "1.0"
   },
   "servers": [
-    {
-      "url": "https://wade-api-qa.azure-api.net/api/v2"
-    }
+      {
+        "url": "https://wade-api-qa.azure-api.net/api/v2"
+      }
   ],
   "paths": {
     "/": {
@@ -547,8 +547,16 @@
         "required": false,
         "schema": {
           "type": "array",
-          "minItems": 4,
-          "maxItems": 4,
+          "oneOf": [
+            {
+              "minItems": 4,
+              "maxItems": 4
+            },
+            {
+              "minItems": 6,
+              "maxItems": 6
+            }
+          ],
           "items": {
             "type": "number"
           }

--- a/source/WaDEApiFunctions/v2/swagger.json
+++ b/source/WaDEApiFunctions/v2/swagger.json
@@ -6,9 +6,9 @@
     "version": "1.0"
   },
   "servers": [
-      {
-        "url": "https://wade-api-qa.azure-api.net/api/v2"
-      }
+    {
+      "url": "https://wade-api-qa.azure-api.net/api/v2"
+    }
   ],
   "paths": {
     "/": {
@@ -52,6 +52,9 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Collections"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
           }
         }
       }
@@ -311,15 +314,6 @@
           },
           {
             "$ref": "#/components/parameters/next"
-          },
-          {
-            "$ref": "#/components/parameters/siteUuids"
-          },
-          {
-            "$ref": "#/components/parameters/overlayUuids"
-          },
-          {
-            "$ref": "#/components/parameters/allocationUuids"
           }
         ],
         "responses": {
@@ -573,16 +567,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "explode": false
-      },
-      "collectionId": {
-        "name": "collectionId",
-        "in": "path",
-        "description": "local identifier of a collection",
-        "required": true,
-        "schema": {
-          "type": "string"
         }
       },
       "coords": {
@@ -597,7 +581,7 @@
       "datetime": {
         "name": "datetime",
         "in": "query",
-        "description": "Either a date-time or an interval. Date and time expressions adhere to RFC 3339.\nIntervals may be bounded or half-bounded (double-dots at start or end).\n\nExamples:\n\n* A date-time: \"2018-02-12T23:20:50Z\"\n* A bounded interval: \"2018-02-12T00:00:00Z/2018-03-18T12:31:12Z\"\n* Half-bounded intervals: \"2018-02-12T00:00:00Z/..\" or \"../2018-03-18T12:31:12Z\"\n\nOnly features that have a temporal property that intersects the value of\n`datetime` are selected.\n\nIf a feature has multiple temporal properties, it is the decision of the\nserver whether only a single temporal property is used to determine\nthe extent or all relevant temporal properties.",
+        "description": "Either a date-time or an interval. Date and time expressions adhere to RFC 3339.\nIntervals may be bounded or half-bounded (double-dots at start or end).\n\nExamples:\n\n* A date-time: \"2018-02-12T23:20:50Z\"\n* A bounded interval: \"2018-02-12T00:00:00Z/2018-03-18T12:31:12Z\"\n* Half-bounded intervals: \"2018-02-12T00:00:00Z/..\" or \"../2018-03-18T12:31:12Z\"\n\nOnly features that have a temporal property that intersects the value of\n`datetime` are selected.",
         "required": false,
         "schema": {
           "type": "string"
@@ -617,13 +601,13 @@
       "limit": {
         "name": "limit",
         "in": "query",
-        "description": "The optional limit parameter limits the number of items that are presented in the response document.\n\nOnly items are counted that are on the first level of the collection in the response document.\nNested objects contained within the explicitly requested items shall not be counted.\n\nMinimum = 1. Maximum = 10000. Default = 10.",
+        "description": "The optional limit parameter limits the number of items that are presented in the response document.\n\nOnly items are counted that are on the first level of the collection in the response document.\nNested objects contained within the explicitly requested items shall not be counted.\n\nMinimum = 1. Maximum = 1000. Default = 1000.",
         "required": false,
         "schema": {
           "type": "integer",
           "minimum": 1,
-          "maximum": 10000,
-          "default": 10
+          "maximum": 1000,
+          "default": 1000
         },
         "style": "form",
         "explode": false
@@ -671,8 +655,7 @@
           "items": {
             "type": "string"
           }
-        },
-        "explode": false
+        }
       },
       "siteUuids": {
         "name": "siteUuids",
@@ -684,8 +667,7 @@
           "items": {
             "type": "string"
           }
-        },
-        "explode": false
+        }
       },
       "states": {
         "name": "states",
@@ -1087,7 +1069,6 @@
               "conformsTo": [
                 "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
                 "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
-                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html",
                 "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"
               ]
             }

--- a/source/WaDEApiFunctions/v2/swagger.json
+++ b/source/WaDEApiFunctions/v2/swagger.json
@@ -589,6 +589,7 @@
         "name": "coords",
         "in": "query",
         "description": "Only data that has a geometry that intersects the area defined by the polygon are selected.\\n\\nThe polygon is defined using a Well Known Text string following\\n\\ncoords=POLYGON((x y,x1 y1,x2 y2,...,xn yn x y)).",
+        "required": true,
         "schema": {
           "type": "string"
         }

--- a/source/WaDEApiFunctions/v2/swagger.json
+++ b/source/WaDEApiFunctions/v2/swagger.json
@@ -547,16 +547,8 @@
         "required": false,
         "schema": {
           "type": "array",
-          "oneOf": [
-            {
-              "minItems": 4,
-              "maxItems": 4
-            },
-            {
-              "minItems": 6,
-              "maxItems": 6
-            }
-          ],
+          "minItems": 4,
+          "maxItems": 4,
           "items": {
             "type": "number"
           }
@@ -825,18 +817,10 @@
                 "type": "array",
                 "minItems": 1,
                 "items": {
-                  "description": "Each bounding box is provided as four or six numbers, depending on\nwhether the coordinate reference system includes a vertical axis\n(height or depth):\n\n* Lower left corner, coordinate axis 1\n* Lower left corner, coordinate axis 2\n* Minimum value, coordinate axis 3 (optional)\n* Upper right corner, coordinate axis 1\n* Upper right corner, coordinate axis 2\n* Maximum value, coordinate axis 3 (optional)\n\nThe coordinate reference system of the values is WGS 84 longitude/latitude\n(http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different coordinate\nreference system is specified in `crs`.\n\nFor WGS 84 longitude/latitude the values are in most cases the sequence of\nminimum longitude, minimum latitude, maximum longitude and maximum latitude.\nHowever, in cases where the box spans the antimeridian the first value\n(west-most box edge) is larger than the third value (east-most box edge).\n\nIf the vertical axis is included, the third and the sixth number are\nthe bottom and the top of the 3-dimensional bounding box.\n\nIf a feature has multiple spatial geometry properties, it is the decision of the\nserver whether only a single spatial geometry property is used to determine\nthe extent or all relevant geometries.",
+                  "description": "Each bounding box is provided as four or six numbers, depending on\nwhether the coordinate reference system includes a vertical axis\n(height or depth):\n\n* Lower left corner, coordinate axis 1\n* Lower left corner, coordinate axis 2\n* Upper right corner, coordinate axis 1\n* Upper right corner, coordinate axis 2\n\nThe coordinate reference system of the values is WGS 84 longitude/latitude\n(http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different coordinate\nreference system is specified in `crs`.\n\nFor WGS 84 longitude/latitude the values are in most cases the sequence of\nminimum longitude, minimum latitude, maximum longitude and maximum latitude.\nHowever, in cases where the box spans the antimeridian the first value\n(west-most box edge) is larger than the third value (east-most box edge).\n\nIf the vertical axis is included, the third and the sixth number are\nthe bottom and the top of the 3-dimensional bounding box.\n\nIf a feature has multiple spatial geometry properties, it is the decision of the\nserver whether only a single spatial geometry property is used to determine\nthe extent or all relevant geometries.",
                   "type": "array",
-                  "oneOf": [
-                    {
-                      "minItems": 4,
-                      "maxItems": 4
-                    },
-                    {
-                      "minItems": 6,
-                      "maxItems": 6
-                    }
-                  ],
+                  "minItems": 4,
+                  "maxItems": 4,
                   "items": {
                     "type": "number"
                   },
@@ -922,7 +906,7 @@
       },
       "featureGeoJSON": {
         "type": "object",
-        "required": ["type", "geometry", "properties"],
+        "required": ["id", "type", "geometry", "properties"],
         "properties": {
           "type": {
             "type": "string",

--- a/source/WaDEApiFunctions/v2/swagger.json
+++ b/source/WaDEApiFunctions/v2/swagger.json
@@ -1,0 +1,1207 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "WaDE OGC API",
+    "description": "WaDE API that conforms to the OGC API features and environmental data retrieval specification.",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://wade-api-qa.azure-api.net/api/v2"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": ["Capabilities"],
+        "summary": "Landing Page",
+        "description": "The landing page provides links to the API definition, the conformance\nstatements and to the feature collections in this dataset.",
+        "operationId": "getLandingPage",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LandingPage"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/conformance": {
+      "get": {
+        "tags": ["Capabilities"],
+        "summary": "Conformance",
+        "description": "Conformance declaration for the OGC API.",
+        "operationId": "getConformance",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ConformanceDeclaration"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/collections": {
+      "get": {
+        "tags": ["Capabilities"],
+        "summary": "Discovery",
+        "description": "Collections",
+        "operationId": "getCollections",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Collections"
+          }
+        }
+      }
+    },
+    "/collections/overlays": {
+      "get": {
+        "tags": ["Overlays"],
+        "summary": "Overlays collection metadata",
+        "description": "WaDE overlays collection.",
+        "operationId": "getOverlaysCollections",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/collections/overlays/items": {
+      "get": {
+        "tags": ["Overlays"],
+        "summary": "Get overlay collection items",
+        "description": "List of overlays.",
+        "operationId": "getOverlays",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/bbox"
+          },
+          {
+            "$ref": "#/components/parameters/next"
+          },
+          {
+            "$ref": "#/components/parameters/siteUuids"
+          },
+          {
+            "$ref": "#/components/parameters/overlayUuids"
+          },
+          {
+            "$ref": "#/components/parameters/states"
+          },
+          {
+            "$ref": "#/components/parameters/overlayTypes"
+          },
+          {
+            "$ref": "#/components/parameters/waterSourceTypes"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Features"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/overlays/area": {
+      "get": {
+        "tags": ["Overlays"],
+        "summary": "Get overlay collection items in the given area",
+        "description": "List of overlays.",
+        "operationId": "getOverlaysInArea",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/coords"
+          },
+          {
+            "$ref": "#/components/parameters/next"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Features"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/rights": {
+      "get": {
+        "tags": ["Rights"],
+        "summary": "Rights collection metadata",
+        "description": "WaDE water rights collection",
+        "operationId": "getRightsCollection",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/collections/rights/items": {
+      "get": {
+        "tags": ["Rights"],
+        "summary": "Get water right collection items",
+        "description": "Allocations",
+        "operationId": "getRights",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/bbox"
+          },
+          {
+            "$ref": "#/components/parameters/next"
+          },
+          {
+            "$ref": "#/components/parameters/allocationUuids"
+          },
+          {
+            "$ref": "#/components/parameters/siteUuids"
+          },
+          {
+            "$ref": "#/components/parameters/states"
+          },
+          {
+            "$ref": "#/components/parameters/waterSourceTypes"
+          },
+          {
+            "$ref": "#/components/parameters/beneficialUses"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Features"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/rights/area": {
+      "get": {
+        "tags": ["Rights"],
+        "summary": "Get water right for a given area",
+        "description": "Allocations",
+        "operationId": "getRightsInArea",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/coords"
+          },
+          {
+            "$ref": "#/components/parameters/next"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Features"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/sites": {
+      "get": {
+        "tags": ["Sites"],
+        "summary": "Site collection metadata",
+        "description": "WaDE sites collection.",
+        "operationId": "getSiteCollection",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/sites/items": {
+      "get": {
+        "tags": ["Sites"],
+        "summary": "Get water site collection items",
+        "description": "TODO: features of site.",
+        "operationId": "getWaterSites",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/bbox"
+          },
+          {
+            "$ref": "#/components/parameters/next"
+          },
+          {
+            "$ref": "#/components/parameters/siteTypes"
+          },
+          {
+            "$ref": "#/components/parameters/states"
+          },
+          {
+            "$ref": "#/components/parameters/waterSourceTypes"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Features"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/sites/area": {
+      "get": {
+        "tags": ["Sites"],
+        "summary": "Return the data values for the data area defined by the query parameters",
+        "description": "TODO: features of site.",
+        "operationId": "getWaterSitesInArea",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/coords"
+          },
+          {
+            "$ref": "#/components/parameters/next"
+          },
+          {
+            "$ref": "#/components/parameters/siteUuids"
+          },
+          {
+            "$ref": "#/components/parameters/overlayUuids"
+          },
+          {
+            "$ref": "#/components/parameters/allocationUuids"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Features"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/sites/items/{featureId}": {
+      "get": {
+        "tags": ["Sites"],
+        "summary": "Get a water site feature W",
+        "description": "TODO: feature.",
+        "operationId": "getWaterSite",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/featureId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Feature"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/timeSeries": {
+      "get": {
+        "tags": ["Time Series"],
+        "summary": "Time Series collection metadata",
+        "description": "WaDE time series collection.",
+        "operationId": "getTimeSeriesCollections",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/overlays/items/{featureId}": {
+      "get": {
+        "tags": ["Overlays"],
+        "summary": "Get a overlay feature",
+        "description": "TODO: feature.",
+        "operationId": "getOverlay",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/featureId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Feature"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/rights/items/{featureId}": {
+      "get": {
+        "tags": ["Rights"],
+        "summary": "Get a water right feature",
+        "description": "TODO: feature.",
+        "operationId": "getWaterRight",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/featureId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Feature"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/timeSeries/items": {
+      "get": {
+        "tags": ["Time Series"],
+        "summary": "Get time series collection items",
+        "description": "TODO: features of site.",
+        "operationId": "searchTimeSeries",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/bbox"
+          },
+          {
+            "$ref": "#/components/parameters/next"
+          },
+          {
+            "$ref": "#/components/parameters/siteUuids"
+          },
+          {
+            "$ref": "#/components/parameters/states"
+          },
+          {
+            "$ref": "#/components/parameters/waterSourceTypes"
+          },
+          {
+            "$ref": "#/components/parameters/variableTypes"
+          },
+          {
+            "$ref": "#/components/parameters/datetime"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Features"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/timeSeries/area": {
+      "get": {
+        "tags": ["Time Series"],
+        "summary": "Get time series collection items in area.",
+        "description": "TODO: features of site.",
+        "operationId": "searchTimeSeriesInArea",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/coords"
+          },
+          {
+            "$ref": "#/components/parameters/next"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Features"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/collections/timeSeries/items/{featureId}": {
+      "get": {
+        "tags": ["Time Series"],
+        "summary": "Get a site time series",
+        "description": "TODO: feature.",
+        "operationId": "getTimeSeries",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/featureId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Feature"
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidParameter"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "allocationUuids": {
+        "name": "allocationUuids",
+        "in": "query",
+        "description": "Comma separated list of allocation Uuids",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "bbox": {
+        "name": "bbox",
+        "in": "query",
+        "description": "Only features that have a geometry that intersects the bounding box are selected.\nThe bounding box is provided as four or six numbers, depending on whether the\ncoordinate reference system includes a vertical axis (height or depth):\n\n* Lower left corner, coordinate axis 1\n* Lower left corner, coordinate axis 2\n* Minimum value, coordinate axis 3 (optional)\n* Upper right corner, coordinate axis 1\n* Upper right corner, coordinate axis 2\n* Maximum value, coordinate axis 3 (optional)\n\nIf the value consists of four numbers, the coordinate reference system is\nWGS 84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84)\nunless a different coordinate reference system is specified in the parameter `bbox-crs`.\n\nIf the value consists of six numbers, the coordinate reference system is WGS 84\nlongitude/latitude/ellipsoidal height (http://www.opengis.net/def/crs/OGC/0/CRS84h)\nunless a different coordinate reference system is specified in the parameter `bbox-crs`.\n\nThe query parameter `bbox-crs` is specified in OGC API - Features - Part 2: Coordinate\nReference Systems by Reference.\n\nFor WGS 84 longitude/latitude the values are in most cases the sequence of\nminimum longitude, minimum latitude, maximum longitude and maximum latitude.\nHowever, in cases where the box spans the antimeridian the first value\n(west-most box edge) is larger than the third value (east-most box edge).\n\nIf the vertical axis is included, the third and the sixth number are\nthe bottom and the top of the 3-dimensional bounding box.\n\nIf a feature has multiple spatial geometry properties, it is the decision of the\nserver whether only a single spatial geometry property is used to determine\nthe extent or all relevant geometries.",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "oneOf": [
+            {
+              "minItems": 4,
+              "maxItems": 4
+            },
+            {
+              "minItems": 6,
+              "maxItems": 6
+            }
+          ],
+          "items": {
+            "type": "number"
+          }
+        },
+        "style": "form",
+        "explode": false
+      },
+      "beneficialUses": {
+        "name": "beneficialUses",
+        "in": "query",
+        "description": "Comma separated list of beneficial uses",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "explode": false
+      },
+      "collectionId": {
+        "name": "collectionId",
+        "in": "path",
+        "description": "local identifier of a collection",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "coords": {
+        "name": "coords",
+        "in": "query",
+        "description": "Only data that has a geometry that intersects the area defined by the polygon are selected.\\n\\nThe polygon is defined using a Well Known Text string following\\n\\ncoords=POLYGON((x y,x1 y1,x2 y2,...,xn yn x y)).",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "datetime": {
+        "name": "datetime",
+        "in": "query",
+        "description": "Either a date-time or an interval. Date and time expressions adhere to RFC 3339.\nIntervals may be bounded or half-bounded (double-dots at start or end).\n\nExamples:\n\n* A date-time: \"2018-02-12T23:20:50Z\"\n* A bounded interval: \"2018-02-12T00:00:00Z/2018-03-18T12:31:12Z\"\n* Half-bounded intervals: \"2018-02-12T00:00:00Z/..\" or \"../2018-03-18T12:31:12Z\"\n\nOnly features that have a temporal property that intersects the value of\n`datetime` are selected.\n\nIf a feature has multiple temporal properties, it is the decision of the\nserver whether only a single temporal property is used to determine\nthe extent or all relevant temporal properties.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "style": "form",
+        "explode": false
+      },
+      "featureId": {
+        "name": "featureId",
+        "in": "path",
+        "description": "local identifier of a feature",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "limit": {
+        "name": "limit",
+        "in": "query",
+        "description": "The optional limit parameter limits the number of items that are presented in the response document.\n\nOnly items are counted that are on the first level of the collection in the response document.\nNested objects contained within the explicitly requested items shall not be counted.\n\nMinimum = 1. Maximum = 10000. Default = 10.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10000,
+          "default": 10
+        },
+        "style": "form",
+        "explode": false
+      },
+      "next": {
+        "name": "next",
+        "in": "query",
+        "description": "The optional next parameter is used to request the next page of items in a paginated response.\nThe value of the next parameter is the URL to the next page of items.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "overlayTypes": {
+        "name": "overlayTypes",
+        "in": "query",
+        "description": "Comma separated list of overlay types",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "overlayUuids": {
+        "name": "overlayUuids",
+        "in": "query",
+        "description": "Comma separated list of overlay Uuids",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "siteTypes": {
+        "name": "siteTypes",
+        "in": "query",
+        "description": "Comma separated list of site types",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "explode": false
+      },
+      "siteUuids": {
+        "name": "siteUuids",
+        "in": "query",
+        "description": "Comma separated list of site Uuids",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "explode": false
+      },
+      "states": {
+        "name": "states",
+        "in": "query",
+        "description": "Comma separated list of state abbreviations",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "variableTypes": {
+        "name": "variableTypes",
+        "in": "query",
+        "description": "Comma separated list of variable types",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "waterSourceTypes": {
+        "name": "waterSourceTypes",
+        "in": "query",
+        "description": "Comma separated list of water source types",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "schemas": {
+      "collection": {
+        "type": "object",
+        "required": ["id", "links"],
+        "properties": {
+          "id": {
+            "description": "identifier of the collection used, for example, in URIs",
+            "type": "string",
+            "example": "sites"
+          },
+          "title": {
+            "description": "human readable title of the collection",
+            "type": "string",
+            "example": "Water Sites"
+          },
+          "description": {
+            "description": "a description of the features in the collection",
+            "type": "string",
+            "example": "Water Sites Description"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/link"
+            }
+          },
+          "extent": {
+            "$ref": "#/components/schemas/extent"
+          },
+          "itemType": {
+            "description": "indicator about the type of the items in the collection (the default value is 'feature').",
+            "type": "string",
+            "default": "feature"
+          },
+          "crs": {
+            "description": "the list of coordinate reference systems supported by the service",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"],
+            "example": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"]
+          }
+        }
+      },
+      "collections": {
+        "type": "object",
+        "required": ["links", "collections"],
+        "properties": {
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/link"
+            }
+          },
+          "collections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/collection"
+            }
+          },
+          "error": {
+            "$ref": "#/components/schemas/errorBase"
+          }
+        }
+      },
+      "conformance": {
+        "type": "object",
+        "required": ["conformsTo"],
+        "properties": {
+          "conformsTo": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "error": {
+            "$ref": "#/components/schemas/errorBase"
+          }
+        }
+      },
+      "errorBase": {
+        "type": "object",
+        "properties": {
+          "publicMessage": {
+            "type": "string"
+          }
+        }
+      },
+      "extent": {
+        "type": "object",
+        "description": "The extent of the features in the collection. In the Core only spatial and temporal\nextents are specified. Extensions may add additional members to represent other\nextents, for example, thermal or pressure ranges.",
+        "properties": {
+          "spatial": {
+            "description": "The spatial extent of the features in the collection.",
+            "type": "object",
+            "properties": {
+              "bbox": {
+                "description": "One or more bounding boxes that describe the spatial extent of the dataset.\nIn the Core only a single bounding box is supported. Extensions may support\nadditional areas. If multiple areas are provided, the union of the bounding\nboxes describes the spatial extent.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "description": "Each bounding box is provided as four or six numbers, depending on\nwhether the coordinate reference system includes a vertical axis\n(height or depth):\n\n* Lower left corner, coordinate axis 1\n* Lower left corner, coordinate axis 2\n* Minimum value, coordinate axis 3 (optional)\n* Upper right corner, coordinate axis 1\n* Upper right corner, coordinate axis 2\n* Maximum value, coordinate axis 3 (optional)\n\nThe coordinate reference system of the values is WGS 84 longitude/latitude\n(http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different coordinate\nreference system is specified in `crs`.\n\nFor WGS 84 longitude/latitude the values are in most cases the sequence of\nminimum longitude, minimum latitude, maximum longitude and maximum latitude.\nHowever, in cases where the box spans the antimeridian the first value\n(west-most box edge) is larger than the third value (east-most box edge).\n\nIf the vertical axis is included, the third and the sixth number are\nthe bottom and the top of the 3-dimensional bounding box.\n\nIf a feature has multiple spatial geometry properties, it is the decision of the\nserver whether only a single spatial geometry property is used to determine\nthe extent or all relevant geometries.",
+                  "type": "array",
+                  "oneOf": [
+                    {
+                      "minItems": 4,
+                      "maxItems": 4
+                    },
+                    {
+                      "minItems": 6,
+                      "maxItems": 6
+                    }
+                  ],
+                  "items": {
+                    "type": "number"
+                  },
+                  "example": [-180, -90, 180, 90]
+                }
+              },
+              "crs": {
+                "description": "Coordinate reference system of the coordinates in the spatial extent\n(property `bbox`). The default reference system is WGS 84 longitude/latitude.\nIn the Core this is the only supported coordinate reference system.\nExtensions may support additional coordinate reference systems and add\nadditional enum values.",
+                "type": "string",
+                "enum": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"],
+                "default": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+              }
+            }
+          },
+          "temporal": {
+            "description": "The temporal extent of the features in the collection.",
+            "type": "object",
+            "properties": {
+              "interval": {
+                "description": "One or more time intervals that describe the temporal extent of the dataset.\nThe value `null` is supported and indicates an unbounded interval end.\nIn the Core only a single time interval is supported. Extensions may support\nmultiple intervals. If multiple intervals are provided, the union of the\nintervals describes the temporal extent.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "description": "Begin and end times of the time interval. The timestamps are in the\ntemporal coordinate reference system specified in `trs`. By default\nthis is the Gregorian calendar.",
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": {
+                    "type": "string",
+                    "format": "date-time",
+                    "nullable": true
+                  },
+                  "example": ["2011-11-11T12:22:11Z", null]
+                }
+              },
+              "trs": {
+                "description": "Coordinate reference system of the coordinates in the temporal extent\n(property `interval`). The default reference system is the Gregorian calendar.\nIn the Core this is the only supported temporal coordinate reference system.\nExtensions may support additional temporal coordinate reference systems and add\nadditional enum values.",
+                "type": "string",
+                "enum": ["http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"],
+                "default": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
+              }
+            }
+          }
+        }
+      },
+      "exception": {
+        "type": "object",
+        "description": "Information about the exception: an error code plus an optional description.",
+        "required": ["code"],
+        "properties": {
+          "status": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "featureCollectionGeoJSON": {
+        "type": "object",
+        "required": ["type", "features"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["FeatureCollection"]
+          },
+          "features": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/featureGeoJSON"
+            }
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/link"
+            }
+          }
+        }
+      },
+      "featureGeoJSON": {
+        "type": "object",
+        "required": ["type", "geometry", "properties"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["Feature"]
+          },
+          "geometry": {
+            "$ref": "#/components/schemas/geometryGeoJSON"
+          },
+          "properties": {
+            "type": "object",
+            "nullable": true
+          },
+          "id": {
+            "type": "string"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/link"
+            }
+          }
+        }
+      },
+      "geometryGeoJSON": {
+        "type": "object",
+        "required": ["type", "coordinates"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Point",
+              "LineString",
+              "Polygon",
+              "MultiPoint",
+              "MultiLineString",
+              "MultiPolygon"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Coordinates of the geometry, following GeoJSON specification."
+          }
+        }
+      },
+      "geometrycollectionGeoJSON": {
+        "type": "object",
+        "required": ["type", "geometries"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["GeometryCollection"]
+          },
+          "geometries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/geometryGeoJSON"
+            }
+          }
+        }
+      },
+      "landingPage": {
+        "type": "object",
+        "required": ["links"],
+        "properties": {
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/link"
+            }
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "error": {
+            "$ref": "#/components/schemas/errorBase"
+          }
+        }
+      },
+      "link": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "rel": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "responses": {
+      "LandingPage": {
+        "description": "The landing page provides links to the API definition\n(link relations `service-desc` and `service-doc`),\nthe Conformance declaration (path `/conformance`,\nlink relation `conformance`), and the Feature\nCollections (path `/collections`, link relation\n`data`).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/landingPage"
+            },
+            "example": {
+              "title": "Water Data Exchange API",
+              "description": "The Water Data Exchange API provides access to water data.",
+              "links": [
+                {
+                  "href": "http://wade-api-qa.azure-api.net/api/v2/",
+                  "rel": "self",
+                  "type": "application/json",
+                  "title": "this document"
+                },
+                {
+                  "href": "wade-api-qa.azure-api.net/api/v2/swagger.json",
+                  "rel": "service-desc",
+                  "type": "application/vnd.oai.openapi+json;version=3.0",
+                  "title": "the API definition"
+                },
+                {
+                  "href": "wade-api-qa.azure-api.net/api/v2/swagger/ui",
+                  "rel": "service-doc",
+                  "type": "text/html",
+                  "title": "the API documentation"
+                },
+                {
+                  "href": "http://wade-api-qa.azure-api.net/api/v2/conformance",
+                  "rel": "conformance",
+                  "type": "application/json",
+                  "title": "OGC API conformance classes implemented by this server"
+                },
+                {
+                  "href": "http://wade-api-qa.azure-api.net/api/v2/collections",
+                  "rel": "data",
+                  "type": "application/json",
+                  "title": "Information about the feature collections"
+                }
+              ]
+            }
+          },
+          "text/html": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ConformanceDeclaration": {
+        "description": "The URIs of all conformance classes supported by the server.\n\nTo support \"generic\" clients that want to access multiple\nOGC API Features implementations - and not \"just\" a specific\nAPI / server, the server declares the conformance\nclasses it implements and conforms to.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/conformance"
+            },
+            "example": {
+              "conformsTo": [
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html",
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"
+              ]
+            }
+          },
+          "text/html": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Collections": {
+        "description": "The feature collections shared by this API.\n\nThe dataset is organized as one or more feature collections. This resource\nprovides information about and access to the collections.\n\nThe response contains the list of collections. For each collection, a link\nto the items in the collection (path `/collections/{collectionId}/items`,\nlink relation `items`) as well as key information about the collection.\nThis information includes:\n\n* A local identifier for the collection that is unique for the dataset;\n* A list of coordinate reference systems (CRS) in which geometries may be returned by the server. The first CRS is the default coordinate reference system (the default is always WGS 84 with axis order longitude/latitude);\n* An optional title and description for the collection;\n* An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data;\n* An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature').",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/collections"
+            }
+          },
+          "text/html": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Collection": {
+        "description": "Information about the feature collection with id `collectionId`.\n\nThe response contains a link to the items in the collection\n(path `/collections/{collectionId}/items`, link relation `items`)\nas well as key information about the collection. This information\nincludes:\n\n* A local identifier for the collection that is unique for the dataset;\n* A list of coordinate reference systems (CRS) in which geometries may be returned by the server. The first CRS is the default coordinate reference system (the default is always WGS 84 with axis order longitude/latitude);\n* An optional title and description for the collection;\n* An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data;\n* An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature').",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/collection"
+            }
+          },
+          "text/html": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Features": {
+        "description": "The response is a document consisting of features in the collection.\nThe features included in the response are determined by the server\nbased on the query parameters of the request. To support access to\nlarger collections without overloading the client, the API supports\npaged access with links to the next page, if more features are selected\nthat the page size.\n\nThe `bbox` and `datetime` parameter can be used to select only a\nsubset of the features in the collection (the features that are in the\nbounding box or time interval). The `bbox` parameter matches all features\nin the collection that are not associated with a location, too. The\n`datetime` parameter matches all features in the collection that are\nnot associated with a time stamp or interval, too.\n\nThe `limit` parameter may be used to control the subset of the\nselected features that should be returned in the response, the page size.\nEach page include links to support paging (link relation `next`).",
+        "content": {
+          "application/geo+json": {
+            "schema": {
+              "$ref": "#/components/schemas/featureCollectionGeoJSON"
+            }
+          },
+          "text/html": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Feature": {
+        "description": "fetch the feature with id `featureId` in the feature collection\nwith id `collectionId`",
+        "content": {
+          "application/geo+json": {
+            "schema": {
+              "$ref": "#/components/schemas/featureGeoJSON"
+            }
+          },
+          "text/html": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "InvalidParameter": {
+        "description": "A query parameter has an invalid value.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/exception"
+            }
+          },
+          "text/html": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The requested resource does not exist on the server. For example, a path parameter had an incorrect value."
+      },
+      "NotAcceptable": {
+        "description": "Content negotiation failed. For example, the `Accept` header submitted in the request did not support any of the media types supported by the server for the requested resource."
+      },
+      "ServerError": {
+        "description": "A server error occurred.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/exception"
+            }
+          },
+          "text/html": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -66,8 +66,8 @@ public static class QueryableExtensions
             query = filters.GeometrySearch.SpatialRelationType switch
             {
                 SpatialRelationType.Intersects => query.Where(x => x.AllocationBridgeSitesFact.Any(
-                    bridge => (bridge.Site.Geometry.IsValid && bridge.Site.Geometry.Intersects(filters.GeometrySearch.Geometry)) ||
-                              (bridge.Site.SitePoint.IsValid && bridge.Site.SitePoint.Intersects(filters.GeometrySearch.Geometry)))),
+                    bridge => (bridge.Site.Geometry.Intersects(filters.GeometrySearch.Geometry)) ||
+                              (bridge.Site.SitePoint.Intersects(filters.GeometrySearch.Geometry)))),
                 _ => query
             };
 
@@ -124,8 +124,8 @@ public static class QueryableExtensions
             query = filters.GeometrySearch.SpatialRelationType switch
             {
                 SpatialRelationType.Intersects => query.Where(s =>
-                    (s.Site.Geometry.IsValid && s.Site.Geometry.Intersects(filters.GeometrySearch.Geometry)) ||
-                    (s.Site.SitePoint.IsValid && s.Site.SitePoint.Intersects(filters.GeometrySearch.Geometry))),
+                    (s.Site.Geometry.Intersects(filters.GeometrySearch.Geometry)) ||
+                    (s.Site.SitePoint.Intersects(filters.GeometrySearch.Geometry))),
                 _ => query
             };
         }

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -14,8 +14,8 @@ public static class QueryableExtensions
             query = filters.GeometrySearch.SpatialRelationType switch
             {
                 SpatialRelationType.Intersects => query.Where(s =>
-                    (s.Geometry.IsValid && s.Geometry.Intersects(filters.GeometrySearch.Geometry)) ||
-                    (s.SitePoint.IsValid && s.SitePoint.Intersects(filters.GeometrySearch.Geometry))),
+                    (s.Geometry.Intersects(filters.GeometrySearch.Geometry)) ||
+                    (s.SitePoint.Intersects(filters.GeometrySearch.Geometry))),
                 _ => query
             };
         }

--- a/source/WesternStatesWater.WaDE.Common/Ogc/IOgcFeature.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/IOgcFeature.cs
@@ -1,0 +1,13 @@
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+
+namespace WesternStatesWater.WaDE.Common.Ogc;
+
+public interface IOgcFeature
+{
+    public string Type { get; }
+    public string Id { get; set; }
+    public Geometry? Geometry { get; set; }
+    public AttributesTable? Properties { get; set; }
+    public Link[]? Links { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Common/Ogc/OgcFeature.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/OgcFeature.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 
@@ -9,11 +8,11 @@ namespace WesternStatesWater.WaDE.Common.Ogc;
 /// However, the current GeoJSON converters provided by the NetTopologySuite library do not support
 /// adding extra custom properties (referred to as "foreign members") to the JSON output.
 /// </summary>
-public sealed class OgcFeature
+public sealed class OgcFeature : IOgcFeature
 {
-    [JsonPropertyName("type")] public string Type { get; set; } = "Feature";
-    [JsonPropertyName("id")] public required string Id { get; set; }
-    [JsonPropertyName("geometry")] public Geometry? Geometry { get; set; }
-    [JsonPropertyName("properties")] public AttributesTable? Attributes { get; set; }
-    [JsonPropertyName("links")] public Link[]? Links { get; set; }
+    public string Type => "Feature";
+    public string Id { get; set; }
+    public Geometry? Geometry { get; set; }
+    public AttributesTable? Properties { get; set; }
+    public Link[]? Links { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Responses/FeatureItemSearchResponseBase.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Responses/FeatureItemSearchResponseBase.cs
@@ -1,9 +1,14 @@
-using WesternStatesWater.Shared.DataContracts;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
 using WesternStatesWater.WaDE.Common.Ogc;
 
 namespace WesternStatesWater.WaDE.Contracts.Api.Responses;
 
-public abstract class FeatureItemSearchResponseBase : WaterResourceSearchResponseBase
+public abstract class FeatureItemSearchResponseBase : WaterResourceSearchResponseBase, IOgcFeature
 {
-    public OgcFeature Feature { get; set; }
+    public string Type => "Feature";
+    public string Id { get; set; }
+    public Geometry Geometry { get; set; }
+    public AttributesTable Properties { get; set; }
+    public Link[] Links { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcFeaturesFormattingHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcFeaturesFormattingHandlerTests.cs
@@ -77,15 +77,15 @@ public class OgcFeaturesFormattingHandlerTests : OgcFormattingTestBase
         var response = await CreateHandler().Handle(request);
 
         // All attributes are keyed off the FeaturePropertyNameAttributes on the class properties.
-        response.Features[0].Attributes["sp"].Should().Be("string!");
-        response.Features[0].Attributes["nsp"].Should().Be("nullable string!");
-        response.Features[0].Attributes["ip"].Should().Be(1);
-        response.Features[0].Attributes["nip"].Should().Be(2);
-        response.Features[0].Attributes["dp"].Should().Be(3.0);
-        response.Features[0].Attributes["ndp"].Should().Be(4.0);
-        response.Features[0].Attributes["bp"].Should().Be(true);
-        response.Features[0].Attributes["nbp"].Should().Be(false);
-        response.Features[0].Attributes["sap"].Should().BeEquivalentTo(new[] { "string array!" });
+        response.Features[0].Properties["sp"].Should().Be("string!");
+        response.Features[0].Properties["nsp"].Should().Be("nullable string!");
+        response.Features[0].Properties["ip"].Should().Be(1);
+        response.Features[0].Properties["nip"].Should().Be(2);
+        response.Features[0].Properties["dp"].Should().Be(3.0);
+        response.Features[0].Properties["ndp"].Should().Be(4.0);
+        response.Features[0].Properties["bp"].Should().Be(true);
+        response.Features[0].Properties["nbp"].Should().Be(false);
+        response.Features[0].Properties["sap"].Should().BeEquivalentTo(new[] { "string array!" });
     }
 
     [TestMethod]
@@ -105,15 +105,15 @@ public class OgcFeaturesFormattingHandlerTests : OgcFormattingTestBase
         var response = await CreateHandler().Handle(request);
 
         // All attributes are keyed off the FeaturePropertyNameAttributes on the class properties.
-        response.Features[0].Attributes["sp"].Should().Be("string!");
-        response.Features[0].Attributes["nsp"].Should().BeNull();
-        response.Features[0].Attributes["ip"].Should().Be(1);
-        response.Features[0].Attributes["nip"].Should().BeNull();
-        response.Features[0].Attributes["dp"].Should().Be(2.0);
-        response.Features[0].Attributes["ndp"].Should().BeNull();
-        response.Features[0].Attributes["bp"].Should().Be(true);
-        response.Features[0].Attributes["nbp"].Should().BeNull();
-        response.Features[0].Attributes["sap"].Should().BeNull();
+        response.Features[0].Properties["sp"].Should().Be("string!");
+        response.Features[0].Properties["nsp"].Should().BeNull();
+        response.Features[0].Properties["ip"].Should().Be(1);
+        response.Features[0].Properties["nip"].Should().BeNull();
+        response.Features[0].Properties["dp"].Should().Be(2.0);
+        response.Features[0].Properties["ndp"].Should().BeNull();
+        response.Features[0].Properties["bp"].Should().Be(true);
+        response.Features[0].Properties["nbp"].Should().BeNull();
+        response.Features[0].Properties["sap"].Should().BeNull();
     }
 
     [TestMethod]
@@ -136,7 +136,27 @@ public class OgcFeaturesFormattingHandlerTests : OgcFormattingTestBase
         var request = new OgcFeaturesFormattingRequest { Items = [feature] };
         var response = await CreateHandler().Handle(request);
     
-        response.Features[0].Attributes.Count.Should().Be(namedProperties.Length);
+        response.Features[0].Properties.Count.Should().Be(namedProperties.Length);
+    }
+    
+    [TestMethod]
+    public async Task Features_Required_Links()
+    {
+        MockApiContextRequest("/collections/test/items");
+        
+        var request = new OgcFeaturesFormattingRequest()
+        {
+            Items = []
+        };
+
+        // Act
+        var handler = CreateHandler();
+        var response = await handler.Handle(request);
+
+        // Assert
+        response.Links.Should().NotBeNull();
+        response.Links.Should().Contain(link => link.Rel == "self" && link.Type == "application/json");
+        response.Links.Should().Contain(link => link.Rel == "alternate" && link.Type == "application/geo+json");
     }
 
     [TestMethod]
@@ -155,16 +175,7 @@ public class OgcFeaturesFormattingHandlerTests : OgcFormattingTestBase
 
         // Assert
         response.Links.Should().NotBeNull();
-        response.Links.Should().HaveCount(1);
-        response.Links.Should().BeEquivalentTo([
-            new Link
-            {
-                Href = $"{ApiHostName}/collections/test/items",
-                Rel = "self",
-                Title = "This document as JSON",
-                Type = "application/json"
-            }
-        ]);
+        response.Links.Should().NotContain(link => link.Rel == "next");
     }
 
     [TestMethod]

--- a/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcFormattingTestBase.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcFormattingTestBase.cs
@@ -9,14 +9,16 @@ namespace WesternStatesWater.WaDE.Engines.Tests.FormattingEngine;
 public class OgcFormattingTestBase
 {
     protected readonly IContextUtility _contextUtilityMock = Mock.Create<IContextUtility>();
-    protected string SwaggerHostName = "https://proxy.example.com";
+    protected string SwaggerDoc = "https://proxy.example.com/swagger/ui";
+    protected string SwaggerDescription = "https://proxy.example.com/swagger/swagger.json";
     protected string ApiHostName = "https://proxy.example.com/api";
     
     [TestInitialize]
     public void OgcFormattingTestBaseInitialize()
     {
-        Environment.SetEnvironmentVariable("OpenApi__HostNames", SwaggerHostName);
         Environment.SetEnvironmentVariable("OgcApi__Host", ApiHostName);
+        Environment.SetEnvironmentVariable("OgcApi__SwaggerDoc", SwaggerDoc);
+        Environment.SetEnvironmentVariable("OgcApi__SwaggerDescription", SwaggerDescription);
         Environment.SetEnvironmentVariable("OgcApi__Title", "WaDE Tests");
         Environment.SetEnvironmentVariable("OgcApi__Description", "WaDE Test Description");
     }
@@ -24,8 +26,9 @@ public class OgcFormattingTestBase
     [TestCleanup]
     public void OgcFormattingTestBaseCleanup()
     {
-        Environment.SetEnvironmentVariable("OpenApi__HostNames", null);
         Environment.SetEnvironmentVariable("OgcApi__Host", null);
+        Environment.SetEnvironmentVariable("OgcApi__SwaggerDocs", null);
+        Environment.SetEnvironmentVariable("OgcApi__SwaggerDescription", null);
         Environment.SetEnvironmentVariable("OgcApi__Title", null);
         Environment.SetEnvironmentVariable("OgcApi__Description", null);
     }

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
@@ -81,6 +81,13 @@ public class OgcFeaturesFormattingHandler(
             },
             new()
             {
+                Href = $"{OgcHost}/collections/{collectionId}/items/{item.Id}",
+                Rel = "alternate",
+                Type = "application/geo+json",
+                Title = "This feature as JSON"
+            },
+            new()
+            {
                 Href = $"{OgcHost}/collections/{collectionId}/items",
                 Rel = "items",
                 Type = ContentTypeJson,

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
@@ -101,7 +101,7 @@ public class OgcFeaturesFormattingHandler(
         {
             Id = item.Id,
             Geometry = item.Geometry,
-            Attributes = BuildAttributesTable(item),
+            Properties = BuildAttributesTable(item),
             Links = featureLinks.ToArray()
         };
     }

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
@@ -114,6 +114,13 @@ public class OgcFeaturesFormattingHandler(
             {
                 Href = $"{OgcHost}/collections/{GetCollectionId(requestUri)}/items", Rel = "self", Type = ContentTypeJson,
                 Title = "This document as JSON"
+            },
+            new()
+            {
+                Href = $"{OgcHost}/collections/{GetCollectionId(requestUri)}/items", 
+                Rel = "alternate", 
+                Type = "application/geo+json",
+                Title = "This document as JSON"
             }
         ];
 

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
@@ -13,7 +13,7 @@ public abstract class OgcFormattingHandlerBase
     {
         Href = SwaggerDescription,
         Rel = "service-desc",
-        Type = ContentTypeJson,
+        Type = "application/vnd.oai.openapi+json;version=3.0",
         Title = "The API definition in JSON"
     };
 
@@ -21,7 +21,7 @@ public abstract class OgcFormattingHandlerBase
     {
         Href = SwaggerDoc,
         Rel = "service-doc",
-        Type = ContentTypeJson,
+        Type = "text/html",
         Title = "Swagger UI"
     };
     

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
@@ -11,7 +11,7 @@ public abstract class OgcFormattingHandlerBase
 
     protected Link ServiceDescriptionLink => new Link
     {
-        Href = $"{SwaggerHost}/swagger.json",
+        Href = SwaggerDescription,
         Rel = "service-desc",
         Type = ContentTypeJson,
         Title = "The API definition in JSON"
@@ -19,7 +19,7 @@ public abstract class OgcFormattingHandlerBase
 
     protected Link ServiceDocumentLink => new Link
     {
-        Href = $"{SwaggerHost}/swagger/ui",
+        Href = SwaggerDoc,
         Rel = "service-doc",
         Type = ContentTypeJson,
         Title = "Swagger UI"
@@ -40,12 +40,16 @@ public abstract class OgcFormattingHandlerBase
         Type = ContentTypeJson,
         Title = "Resource collections"
     };
-
+    
     /// <summary>
-    /// Swagger host name that comes from the OpenApi:HostNames configuration.
-    /// Use this when you are referencing links in the Swagger specification.
+    /// URL to the Swagger file that describes the API.
     /// </summary>
-    private string SwaggerHost { get; }
+    private string SwaggerDescription { get; }
+    
+    /// <summary>
+    /// URL to the Swagger UI.
+    /// </summary>
+    private string SwaggerDoc { get; set; }
     
     /// <summary>
     /// Host name that comes from the OgcApi:Host configuration.
@@ -60,18 +64,11 @@ public abstract class OgcFormattingHandlerBase
         OgcHost = configuration["OgcApi:Host"] ?? 
                   throw new InvalidOperationException($"{nameof(OgcFormattingHandlerBase)} requires OgcApi:Host configuration to build the specification links.");
         
-        // Uses the OpenApi:HostNames configuration to know the host name of the server.
-        // Open API supports multiple host names, but this engine will only support one at this time.
-        var swaggerHostNames = configuration["OpenApi:HostNames"] ??
-                               throw new InvalidOperationException($"{nameof(OgcFormattingHandlerBase)} requires OpenApi:HostNames configuration to determine swagger links.");
+        SwaggerDoc = configuration["OgcApi:SwaggerDoc"] ?? 
+                  throw new InvalidOperationException($"{nameof(OgcFormattingHandlerBase)} requires OgcApi:SwaggerDoc configuration to build the specification links.");
         
-        var hostNames = swaggerHostNames.Split(',');
-        if (hostNames.Length > 1)
-        {
-            throw new InvalidOperationException($"{nameof(OgcFormattingHandlerBase)} currently only supports one Swagger host name.");
-        }
-
-        SwaggerHost = hostNames[0].Trim();
+        SwaggerDescription = configuration["OgcApi:SwaggerDescription"] ?? 
+                  throw new InvalidOperationException($"{nameof(OgcFormattingHandlerBase)} requires OgcApi:SwaggerDescription configuration to build the specification links.");
     }
 
     /// <summary>

--- a/source/WesternStatesWater.WaDE.Integration.Tests/IntegrationTestsBase.cs
+++ b/source/WesternStatesWater.WaDE.Integration.Tests/IntegrationTestsBase.cs
@@ -29,7 +29,8 @@ public abstract class IntegrationTestsBase
 
     protected IServiceProvider Services { get; private set; } = null!;
     protected static readonly IHttpContextAccessor _httpContextAccessor = Mock.Create<IHttpContextAccessor>();
-    protected string SwaggerHostName = "https://proxy.example.com";
+    protected string SwaggerDoc = "https://proxy.example.com/swagger/ui";
+    protected string SwaggerDescription = "https://proxy.example.com/swagger/swagger.json";
     protected string ApiHostName = "https://proxy.example.com/api";
 
     [TestInitialize]
@@ -39,8 +40,9 @@ public abstract class IntegrationTestsBase
         _transactionScopeFixture = CreateTransactionScope();
         
         // Setup Formatting Engine required configurations.
-        Environment.SetEnvironmentVariable("OpenApi__HostNames", SwaggerHostName);
         Environment.SetEnvironmentVariable("OgcApi__Host", ApiHostName);
+        Environment.SetEnvironmentVariable("OgcApi__SwaggerDoc", SwaggerDoc);
+        Environment.SetEnvironmentVariable("OgcApi__SwaggerDescription", SwaggerDescription);
         Environment.SetEnvironmentVariable("OgcApi__Title", "WaDE Tests");
         Environment.SetEnvironmentVariable("OgcApi__Description", "WaDE Test Description");
     }
@@ -135,8 +137,9 @@ public abstract class IntegrationTestsBase
     {
         _transactionScopeFixture.Dispose();
         
-        Environment.SetEnvironmentVariable("OpenApi__HostNames", null);
         Environment.SetEnvironmentVariable("OgcApi__Host", null);
+        Environment.SetEnvironmentVariable("OgcApi__SwaggerDocs", null);
+        Environment.SetEnvironmentVariable("OgcApi__SwaggerDescription", null);
         Environment.SetEnvironmentVariable("OgcApi__Title", null);
         Environment.SetEnvironmentVariable("OgcApi__Description", null);
     }

--- a/source/WesternStatesWater.WaDE.Integration.Tests/WaterResources/WaterResourceIntegrationTests.cs
+++ b/source/WesternStatesWater.WaDE.Integration.Tests/WaterResources/WaterResourceIntegrationTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NetTopologySuite.IO;
+using WesternStatesWater.Shared.Errors;
 using WesternStatesWater.WaDE.Contracts.Api;
 using WesternStatesWater.WaDE.Contracts.Api.Requests.V1;
 using WesternStatesWater.WaDE.Contracts.Api.Responses.V1;
@@ -108,7 +109,7 @@ public class WaterResourceIntegrationTests : IntegrationTestsBase
         >(request);
 
         // Filtered on geometry, can't find the invalid site.
-        response.Features.Should().BeEmpty();
+        response.Error.Should().BeOfType<InternalError>("invalid sites throws a sql exception");
 
         request = new Contracts.Api.Requests.V2.SiteFeaturesItemRequest
         {

--- a/source/WesternStatesWater.WaDE.Integration.Tests/WaterResources/WaterResourceIntegrationTests.cs
+++ b/source/WesternStatesWater.WaDE.Integration.Tests/WaterResources/WaterResourceIntegrationTests.cs
@@ -198,7 +198,7 @@ public class WaterResourceIntegrationTests : IntegrationTestsBase
             .Be(lincolnSites.Length, "all these points should be in the Lincoln area.");
 
         response.Features
-            .Select(f => f.Attributes["id"])
+            .Select(f => f.Properties["id"])
             .Should()
             .Contain(lincolnSites.Select(s => s.SiteUuid));
 
@@ -218,7 +218,7 @@ public class WaterResourceIntegrationTests : IntegrationTestsBase
             .Be(omahaSites.Length, "all these points should be in the Omaha area.");
 
         response.Features
-            .Select(f => f.Attributes["id"])
+            .Select(f => f.Properties["id"])
             .Should()
             .Contain(omahaSites.Select(s => s.SiteUuid));
 
@@ -267,7 +267,7 @@ public class WaterResourceIntegrationTests : IntegrationTestsBase
             Contracts.Api.Responses.V2.SiteFeaturesSearchResponse
         >(request);
 
-        sites[0].SiteUuid.Should().Be(response.Features[0].Attributes["id"].ToString());
+        sites[0].SiteUuid.Should().Be(response.Features[0].Properties["id"].ToString());
 
         // Use the link to get the next page, but up the limit to 2.
         var next = response.Links.First(link => link.Rel == "next").Href.Split('=').Last();
@@ -282,8 +282,8 @@ public class WaterResourceIntegrationTests : IntegrationTestsBase
             Contracts.Api.Responses.V2.SiteFeaturesSearchResponse
         >(request);
 
-        sites[1].SiteUuid.Should().Be(response.Features[0].Attributes["id"].ToString());
-        sites[2].SiteUuid.Should().Be(response.Features[1].Attributes["id"].ToString());
+        sites[1].SiteUuid.Should().Be(response.Features[0].Properties["id"].ToString());
+        sites[2].SiteUuid.Should().Be(response.Features[1].Properties["id"].ToString());
 
         // Use the link to get the final page. Overshoot the limit for good measure.
         next = response.Links.First(link => link.Rel == "next").Href.Split('=').Last();
@@ -298,7 +298,7 @@ public class WaterResourceIntegrationTests : IntegrationTestsBase
         >(request);
 
         response.Features.Length.Should().Be(1);
-        sites[3].SiteUuid.Should().Be(response.Features[0].Attributes["id"].ToString());
+        sites[3].SiteUuid.Should().Be(response.Features[0].Properties["id"].ToString());
         response.Links.Count(link => link.Rel == "next").Should().Be(0);
     }
     
@@ -343,7 +343,7 @@ public class WaterResourceIntegrationTests : IntegrationTestsBase
             .Be(lincolnSites.Length, "all these points should be in the Lincoln area.");
 
         response.Features
-            .Select(f => f.Attributes["id"])
+            .Select(f => f.Properties["id"])
             .Should()
             .Contain(lincolnSites.Select(s => s.SiteUuid));
 
@@ -369,7 +369,7 @@ public class WaterResourceIntegrationTests : IntegrationTestsBase
             .Be(omahaSites.Length, "all these points should be in the Omaha area.");
 
         response.Features
-            .Select(f => f.Attributes["id"])
+            .Select(f => f.Properties["id"])
             .Should()
             .Contain(omahaSites.Select(s => s.SiteUuid));
 

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
@@ -36,18 +36,31 @@ public class OgcApiProfile : Profile
             Contracts.Api.Responses.V2.RightFeaturesSearchResponse>();
         CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
             Contracts.Api.Responses.V2.TimeSeriesFeaturesSearchResponse>();
+        
         CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
+            Contracts.Api.Responses.V2.SiteFeatureItemGetResponse>();
+        CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
+            Contracts.Api.Responses.V2.RightFeatureItemGetResponse>();
+        CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
+            Contracts.Api.Responses.V2.OverlayFeatureItemGetResponse>();
+        CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
+            Contracts.Api.Responses.V2.TimeSeriesFeatureItemGetResponse>();
+
+        CreateMap<Engines.Contracts.Ogc.Responses.FeaturesResponseBase,
+            Contracts.Api.Responses.FeatureItemSearchResponseBase>()
+            .Include<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
                 Contracts.Api.Responses.V2.SiteFeatureItemGetResponse>()
-            .ForMember(dest => dest.Feature, mem => mem.MapFrom(src => src.Features[0]));
-        CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
+            .Include<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
                 Contracts.Api.Responses.V2.RightFeatureItemGetResponse>()
-            .ForMember(dest => dest.Feature, mem => mem.MapFrom(src => src.Features[0]));
-        CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
+            .Include<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
                 Contracts.Api.Responses.V2.OverlayFeatureItemGetResponse>()
-            .ForMember(dest => dest.Feature, mem => mem.MapFrom(src => src.Features[0]));
-        CreateMap<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
+            .Include<Engines.Contracts.Ogc.Responses.OgcFeaturesFormattingResponse,
                 Contracts.Api.Responses.V2.TimeSeriesFeatureItemGetResponse>()
-            .ForMember(dest => dest.Feature, mem => mem.MapFrom(src => src.Features[0]));
+            .ForMember(dest => dest.Id, mem => mem.MapFrom(src => src.Features[0].Id))
+            .ForMember(dest => dest.Geometry, mem => mem.MapFrom(src => src.Features[0].Geometry))
+            .ForMember(dest => dest.Type, mem => mem.MapFrom(src => src.Features[0].Type))
+            .ForMember(dest => dest.Links, mem => mem.MapFrom(src => src.Features[0].Links))
+            .ForMember(dest => dest.Properties, mem => mem.MapFrom(src => src.Features[0].Properties));
 
         // Managers -> Accessors
         CreateMap<Contracts.Api.Requests.V2.SiteFeaturesItemRequest,

--- a/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/OverlayFeatureItemGetRequestHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/OverlayFeatureItemGetRequestHandlerTests.cs
@@ -74,7 +74,6 @@ public class OverlayFeatureItemGetRequestHandlerTests
 
         // Assert
         response.Should().NotBeNull();
-        response.Feature.Should().NotBeNull();
     }
 
     [TestMethod]
@@ -109,7 +108,6 @@ public class OverlayFeatureItemGetRequestHandlerTests
         
         // Assert
         formatEngineExpectation.OccursNever();
-        response.Feature.Should().BeNull();
         response.Error.Should().BeOfType<NotFoundError>();
     }
 
@@ -145,7 +143,6 @@ public class OverlayFeatureItemGetRequestHandlerTests
         
         // Assert
         formatEngineExpectation.OccursNever();
-        response.Feature.Should().BeNull();
         response.Error.Should().BeOfType<NotFoundError>();
     }
 

--- a/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/RightFeatureItemGetRequestHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/RightFeatureItemGetRequestHandlerTests.cs
@@ -74,7 +74,6 @@ public class RightFeatureItemGetRequestHandlerTests
 
         // Assert
         response.Should().NotBeNull();
-        response.Feature.Should().NotBeNull();
     }
 
     [TestMethod]
@@ -109,7 +108,6 @@ public class RightFeatureItemGetRequestHandlerTests
         
         // Assert
         formatEngineExpectation.OccursNever();
-        response.Feature.Should().BeNull();
         response.Error.Should().BeOfType<NotFoundError>();
     }
 
@@ -145,7 +143,6 @@ public class RightFeatureItemGetRequestHandlerTests
         
         // Assert
         formatEngineExpectation.OccursNever();
-        response.Feature.Should().BeNull();
         response.Error.Should().BeOfType<NotFoundError>();
     }
 

--- a/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/SiteFeatureItemGetRequestHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/SiteFeatureItemGetRequestHandlerTests.cs
@@ -75,7 +75,6 @@ public class SiteFeatureItemGetRequestHandlerTests
         
         // Assert
         response.Should().NotBeNull();
-        response.Feature.Should().NotBeNull();
     }
 
     [TestMethod]
@@ -110,7 +109,6 @@ public class SiteFeatureItemGetRequestHandlerTests
         
         // Assert
         formatEngineExpectation.OccursNever();
-        response.Feature.Should().BeNull();
         response.Error.Should().BeOfType<NotFoundError>();
     }
     
@@ -146,7 +144,6 @@ public class SiteFeatureItemGetRequestHandlerTests
         
         // Assert
         formatEngineExpectation.OccursNever();
-        response.Feature.Should().BeNull();
         response.Error.Should().BeOfType<NotFoundError>();
     }
     

--- a/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/TimeSeriesFeatureItemGetRequestHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/TimeSeriesFeatureItemGetRequestHandlerTests.cs
@@ -72,7 +72,6 @@ public class TimeSeriesFeatureItemGetRequestHandlerTests
 
         // Assert
         response.Should().NotBeNull();
-        response.Feature.Should().NotBeNull();
     }
 
     [TestMethod]
@@ -107,7 +106,6 @@ public class TimeSeriesFeatureItemGetRequestHandlerTests
 
         // Assert
         formatEngineExpectation.OccursNever();
-        response.Feature.Should().BeNull();
         response.Error.Should().BeOfType<NotFoundError>();
     }
 
@@ -143,7 +141,6 @@ public class TimeSeriesFeatureItemGetRequestHandlerTests
 
         // Assert
         formatEngineExpectation.OccursNever();
-        response.Feature.Should().BeNull();
         response.Error.Should().BeOfType<NotFoundError>();
     }
 


### PR DESCRIPTION
The following changes were to address changes needed for the OGC API Features Compliance test.

* Wired up endpoints to handle non 200 requests.
* Two new configuration properties. We need our server to be able to point to the swagger definition in one place, and the swagger UI in another. Our swagger definition will point to the github file on the `develop` or `master` branch. Swagger Doc will point to Swagger Hub.
* Stripped out OpenAPI package. Package didn't support all the Open API features we need to support like applying `minimum` and `maximum` schema values. Worth revisiting when we move to .NET9+.