### PR TITLE
V2 Water Right Items - Priority Date Filtering

### DIFF
--- a/source/WaDEApiFunctions/v2/RightsFunction.cs
+++ b/source/WaDEApiFunctions/v2/RightsFunction.cs
@@ -42,6 +42,7 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
             Bbox = req.Query["bbox"],
             Limit = req.Query["limit"],
             Next = req.Query["next"],
+            DateTime = req.Query["datetime"],
             AllocationUuids = req.Query["allocationUuids"],
             SiteUuids = req.Query["siteUuids"],
             States = req.Query["states"],

--- a/source/WaDEApiFunctions/v2/swagger.json
+++ b/source/WaDEApiFunctions/v2/swagger.json
@@ -183,6 +183,9 @@
             "$ref": "#/components/parameters/next"
           },
           {
+            "$ref": "#/components/parameters/datetime"
+          },
+          {
             "$ref": "#/components/parameters/allocationUuids"
           },
           {

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/AllocationSearchRequest.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/Requests/AllocationSearchRequest.cs
@@ -12,6 +12,8 @@ public class AllocationSearchRequest : SearchRequestBase
     
     public SpatialSearchCriteria GeometrySearch { get; set; }
     
+    public DateRangeFilter PriorityDate { get; set; }
+    
     public List<string> States { get; set; }
     
     public List<string> WaterSourceTypes { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -102,6 +102,19 @@ public static class QueryableExtensions
             query = query.Where(x => x.AllocationBridgeBeneficialUsesFact.Any(
                 bridge => filters.BeneficialUses.Contains(bridge.BeneficialUse.WaDEName)));
         }
+        
+        if (filters.PriorityDate != null)
+        {
+            if (filters.PriorityDate.StartDate != null)
+            {
+                query = query.Where(x => x.AllocationPriorityDateNavigation.Date >= filters.PriorityDate.StartDate);
+            }
+
+            if (filters.PriorityDate.EndDate != null)
+            {
+                query = query.Where(x => x.AllocationPriorityDateNavigation.Date <= filters.PriorityDate.EndDate);
+            }
+        }
 
         if (!string.IsNullOrWhiteSpace(filters.LastKey))
         {

--- a/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/RightFeaturesItemRequest.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/Requests/V2/RightFeaturesItemRequest.cs
@@ -7,4 +7,8 @@ public class RightFeaturesItemRequest : RightFeaturesSearchRequestBase
     public string States { get; set; }
     public string WaterSourceTypes { get; set; }
     public string BeneficialUses { get; set; }
+    /// <summary>
+    /// OGC API DateTime parameter used for Priority Date
+    /// </summary>
+    public string DateTime { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
@@ -175,6 +175,7 @@ public class OgcApiProfile : Profile
             .ForMember(dest => dest.States, mem => mem.Ignore())
             .ForMember(dest => dest.WaterSourceTypes, mem => mem.Ignore())
             .ForMember(dest => dest.BeneficialUses, mem => mem.Ignore())
+            .ForMember(dest => dest.PriorityDate, opt => opt.Ignore())
             .ForMember(dest => dest.GeometrySearch, mem => mem.MapFrom(src => src))
             .ForMember(dest => dest.LastKey, opt => opt.MapFrom(src => src.Next));
 
@@ -239,6 +240,7 @@ public class OgcApiProfile : Profile
             .ForMember(dest => dest.BeneficialUses, mem => mem.Ignore())
             .ForMember(dest => dest.GeometrySearch, mem => mem.Ignore())
             .ForMember(dest => dest.LastKey, mem => mem.Ignore())
+            .ForMember(dest => dest.PriorityDate, mem => mem.Ignore())
             .ForMember(dest => dest.Limit, mem => mem.MapFrom(src => 1))
             .ForMember(dest => dest.AllocationUuid, mem => mem.MapFrom(src => new List<string> { src.Id }));
 

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/OgcApiProfile.cs
@@ -165,7 +165,8 @@ public class OgcApiProfile : Profile
                 opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.SiteUuids))
             .ForMember(dest => dest.States,
                 opt => opt.ConvertUsing(new CommaStringToListConverter(), src => src.States))
-            .ForMember(dest => dest.LastKey, opt => opt.MapFrom(src => src.Next));
+            .ForMember(dest => dest.LastKey, opt => opt.MapFrom(src => src.Next))
+            .ForMember(dest => dest.PriorityDate, opt => opt.ConvertUsing(new OgcDateTimeConverter(), src => src.DateTime));
 
         CreateMap<Contracts.Api.Requests.V2.RightFeaturesAreaRequest,
                 Accessors.Contracts.Api.V2.Requests.AllocationSearchRequest>()


### PR DESCRIPTION
Updated the `/collections/rights/items` endpoint to use the OGC API `datetime` parameter to filter allocation amounts priority date.

Exact match example:
`/collections/rights/items?datetime=2022-01-01T00:00:00.000Z/2022-12-31T00:00:00.000Z`

Half bounded start example:
`/collections/rights/items?datetime=../2022-12-31T00:00:00.000Z`
`/collections/rights/items?datetime=/2022-12-31T00:00:00.000Z`

Half bounded end example:
`/collections/rights/items?datetime=2022-01-01T00:00:00.000Z/..`
`/collections/rights/items?datetime=2022-01-01T00:00:00.000Z/`