### PR TITLE
OGC API EDR Updates

### DIFF
--- a/source/WaDEApiFunctions/FunctionBase.cs
+++ b/source/WaDEApiFunctions/FunctionBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Net;
 using System.Text.Json;
@@ -41,6 +42,15 @@ public abstract class FunctionBase
         return response switch
         {
             { Error: null } => await CreateOkResponse(request, response),
+            _ => await CreateErrorResponse(request, response.Error),
+        };
+    }
+
+    protected async Task<HttpResponseData> CreateUnwrappedResponse<T, TResult>(HttpRequestData request, T response,  Func<T, TResult> selector) where T : ResponseBase
+    {
+        return response switch
+        {
+            { Error: null } => await CreateOkResponse(request, selector(response)),
             _ => await CreateErrorResponse(request, response.Error),
         };
     }

--- a/source/WaDEApiFunctions/FunctionBase.cs
+++ b/source/WaDEApiFunctions/FunctionBase.cs
@@ -46,11 +46,20 @@ public abstract class FunctionBase
         };
     }
 
-    protected async Task<HttpResponseData> CreateUnwrappedResponse<T, TResult>(HttpRequestData request, T response,  Func<T, TResult> selector) where T : ResponseBase
+    /// <summary>
+    /// Creates an HTTP response based on the provided response object and a property selector function.
+    /// </summary>
+    /// <param name="request">The HTTP request data.</param>
+    /// <param name="response">The response object containing the data or error information.</param>
+    /// <param name="propertySelector">A function to select a specific property from the response object.</param>
+    /// <typeparam name="T">The type of the response object.</typeparam>
+    /// <typeparam name="TResult">The type of the selected property.</typeparam>
+    /// <returns>An HTTP response with the selected property or an error response.</returns>
+    protected async Task<HttpResponseData> CreateResponse<T, TResult>(HttpRequestData request, T response,  Func<T, TResult> propertySelector) where T : ResponseBase
     {
         return response switch
         {
-            { Error: null } => await CreateOkResponse(request, selector(response)),
+            { Error: null } => await CreateOkResponse(request, propertySelector(response)),
             _ => await CreateErrorResponse(request, response.Error),
         };
     }

--- a/source/WaDEApiFunctions/v2/OverlaysFunction.cs
+++ b/source/WaDEApiFunctions/v2/OverlaysFunction.cs
@@ -22,7 +22,7 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateUnwrappedResponse(req, response, r => r.Collection);
+        return await CreateResponse(req, response, r => r.Collection);
     }
 
     [Function(nameof(GetOverlays))]

--- a/source/WaDEApiFunctions/v2/OverlaysFunction.cs
+++ b/source/WaDEApiFunctions/v2/OverlaysFunction.cs
@@ -22,7 +22,7 @@ public class OverlaysFunction(IMetadataManager metadataManager, IWaterResourceMa
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateResponse(req, response);
+        return await CreateUnwrappedResponse(req, response, r => r.Collection);
     }
 
     [Function(nameof(GetOverlays))]

--- a/source/WaDEApiFunctions/v2/RightsFunction.cs
+++ b/source/WaDEApiFunctions/v2/RightsFunction.cs
@@ -21,7 +21,7 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateResponse(req, response);
+        return await CreateUnwrappedResponse(req, response, r => r.Collection);
     }
 
     [Function(nameof(GetRights))]

--- a/source/WaDEApiFunctions/v2/RightsFunction.cs
+++ b/source/WaDEApiFunctions/v2/RightsFunction.cs
@@ -21,7 +21,7 @@ public class RightsFunction(IMetadataManager metadataManager, IWaterResourceMana
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateUnwrappedResponse(req, response, r => r.Collection);
+        return await CreateResponse(req, response, r => r.Collection);
     }
 
     [Function(nameof(GetRights))]

--- a/source/WaDEApiFunctions/v2/SitesFunction.cs
+++ b/source/WaDEApiFunctions/v2/SitesFunction.cs
@@ -23,7 +23,7 @@ public class WaterSitesFunction(
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateResponse(req, response);
+        return await CreateUnwrappedResponse(req, response, r => r.Collection);
     }
 
     [Function(nameof(GetWaterSites))]

--- a/source/WaDEApiFunctions/v2/SitesFunction.cs
+++ b/source/WaDEApiFunctions/v2/SitesFunction.cs
@@ -23,7 +23,7 @@ public class WaterSitesFunction(
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateUnwrappedResponse(req, response, r => r.Collection);
+        return await CreateResponse(req, response, r => r.Collection);
     }
 
     [Function(nameof(GetWaterSites))]

--- a/source/WaDEApiFunctions/v2/TimeSeriesFunction.cs
+++ b/source/WaDEApiFunctions/v2/TimeSeriesFunction.cs
@@ -22,7 +22,7 @@ public class TimeSeriesFunction(IMetadataManager metadataManager, IWaterResource
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateResponse(req, response);
+        return await CreateUnwrappedResponse(req, response, r => r.Collection);
     }
 
     [Function(nameof(SearchTimeSeries))]

--- a/source/WaDEApiFunctions/v2/TimeSeriesFunction.cs
+++ b/source/WaDEApiFunctions/v2/TimeSeriesFunction.cs
@@ -22,7 +22,7 @@ public class TimeSeriesFunction(IMetadataManager metadataManager, IWaterResource
     {
         var request = new CollectionMetadataGetRequest();
         var response = await metadataManager.Load<CollectionMetadataGetRequest, CollectionMetadataGetResponse>(request);
-        return await CreateUnwrappedResponse(req, response, r => r.Collection);
+        return await CreateResponse(req, response, r => r.Collection);
     }
 
     [Function(nameof(SearchTimeSeries))]

--- a/source/WesternStatesWater.WaDE.Accessors/WaterAllocationAccessor.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/WaterAllocationAccessor.cs
@@ -321,6 +321,19 @@ namespace WesternStatesWater.WaDE.Accessors
                 .MinAsync(fact => fact.AllocationPriorityDateNavigation.Date);
             return new AccessorApi.AllocationMetadata
             {
+                // Due to the calculating boundary box for all sites is an expensive db operation,
+                // we are hardcoding the boundary box.
+                // Note: If we do calculate bound box, be aware not all site geometries are valid.
+
+                // View of bounding box: https://linestrings.com/bbox/#-180,18,-93,72
+                BoundaryBox = new AccessorApi.BoundaryBox
+                {
+                    Crs = "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                    MinX = -180,
+                    MinY = 18,
+                    MaxX = -93,
+                    MaxY = 72
+                },
                 IntervalStartDate = minStartDate,
                 IntervalEndDate = null
             };

--- a/source/WesternStatesWater.WaDE.Common/Ogc/Collection.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/Collection.cs
@@ -1,11 +1,60 @@
 namespace WesternStatesWater.WaDE.Common.Ogc;
 
+/// <summary>
+/// EDR Collection Object Structure.
+/// https://docs.ogc.org/is/19-086r6/19-086r6.html#_b6db449c-4ca7-4117-9bf4-241984cef569
+/// </summary>
 public class Collection
 {
+    /// <summary>
+    /// Unique identifier string for the collection, used as the value for the collection_id path parameter in all queries on the collection
+    /// </summary>
     public required string Id { get; set; }
+    
+    /// <summary>
+    /// Array of link objects
+    /// </summary>
     public required Link[] Links { get; set; }
+    
+    /// <summary>
+    /// A short text label for the collection
+    /// </summary>
+    public string? Title { get; set; }
+    
+    /// <summary>
+    /// A text description of the information provided by the collection
+    /// </summary>
+    public string? Description { get; set; }
+    
+    /// <summary>
+    /// Array of words and phrases that define the information that the collection provides
+    /// </summary>
+    public string[]? Keywords { get; set; }
+    
+    /// <summary>
+    /// Array of coordinate reference system names, which define the output coordinate systems supported by the collection
+    /// </summary>
     public string[]? Crs { get; set; }
     public string? ItemType { get; set; }
     public string? StorageCrs { get; set; }
+    
+    /// <summary>
+    /// Object describing the spatio-temporal extent of the information provided by the collection
+    /// </summary>
     public Extent? Extent { get; set; }
+    
+    /// <summary>
+    /// Object providing query specific information
+    /// </summary>
+    public Dictionary<string, DataQuery>? DataQueries { get; set; }
+    
+    /// <summary>
+    /// Array of data format names, which define the data formats to which information in the collection can be output
+    /// </summary>
+    public string[] OutputFormats { get; set; }
+    
+    /// <summary>
+    /// Describes the data values available in the collection
+    /// </summary>
+    public required Dictionary<string, Parameter> ParameterNames { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Common/Ogc/CrsDetail.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/CrsDetail.cs
@@ -1,0 +1,17 @@
+namespace WesternStatesWater.WaDE.Common.Ogc;
+
+/// <summary>
+/// Describes a coordinate system.
+/// </summary>
+public class CrsDetail
+{
+    /// <summary>
+    /// Name of the coordinate reference system, used as the value in the crs query parameter to define the required output coordinate reference system
+    /// </summary>
+    public required string Crs { get; set; }
+    
+    /// <summary>
+    /// Well Known Text description of the coordinate reference system
+    /// </summary>
+    public required string Wkt { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Common/Ogc/DataQuery.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/DataQuery.cs
@@ -1,0 +1,10 @@
+namespace WesternStatesWater.WaDE.Common.Ogc;
+
+/// <summary>
+/// The EDR query object provides the metadata for the specified query type.
+/// https://docs.ogc.org/is/19-086r6/19-086r6.html#_9a6620ce-6093-4b1b-8f68-2e2c04a13746
+/// </summary>
+public class DataQuery
+{
+    public required Link Link { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Common/Ogc/Link.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/Link.cs
@@ -2,8 +2,38 @@ namespace WesternStatesWater.WaDE.Common.Ogc;
 
 public class Link
 {
+    /// <summary>
+    /// URL being referenced
+    /// </summary>
     public required string Href { get; set; }
+    
+    /// <summary>
+    /// Relation type of the URL. A list of valid relation types can be found at http://www.opengis.net/def/rel
+    /// </summary>
     public required string Rel { get; set; }
+    
+    /// <summary>
+    /// Type of information being returned by the URL
+    /// </summary>
     public string? Type { get; set; }
+    
+    /// <summary>
+    /// Attribute used to specify the language and geographical targeting of information accessed by the URL. Can be defined by using a value from either languages ISO 639-1 or countries ISO 3166-1
+    /// </summary>
+    public string? Hreflang { get; set; }
+    
+    /// <summary>
+    /// A short text label to describe the URL
+    /// </summary>
     public string? Title { get; set; }
+    
+    /// <summary>
+    /// If True the URL includes templated values for mandatory Query parameters
+    /// </summary>
+    public bool? Templated { get; set; }
+    
+    /// <summary>
+    /// Object providing custom information relevant to the link
+    /// </summary>
+    public Variable? Variables { get; set; }
 }

--- a/source/WesternStatesWater.WaDE.Common/Ogc/MeasurementType.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/MeasurementType.cs
@@ -1,0 +1,21 @@
+namespace WesternStatesWater.WaDE.Common.Ogc;
+
+/// <summary>
+/// The measurementType object provides basic information about how the parameter is calculated and over what time period.
+/// https://docs.ogc.org/is/19-086r6/19-086r6.html#_c81181d6-fd09-454e-9c00-a3bb3b21d592
+/// </summary>
+public class MeasurementType
+{
+    /// <summary>
+    /// Calculation method e.g. Mean, Sum, Max, etc.
+    /// </summary>
+    public required string Method { get; set; }
+
+    /// <summary>
+    /// Duration of calculation. For time durations, this follows the ISO 8601 Duration standard.
+    ///
+    /// A negative sign before a duration value (i.e. -PT10M) infers that the time start starts at the specified duration before the time value assigned to the parameter value.
+    /// So if the measurement had a time value of 2020-04-05T14:30Z and a measurementType duration of -PT10M the value is representative of the period 2020-04-05T14:20Z/2020-04-05T14:30Z; if the measurement had a time value of 2020-04-05T14:30Z and a measurementType duration of PT10M the value is representative of the period 2020-04-05T14:30Z/2020-04-05T14:40Z
+    /// </summary>
+    public required string Duration { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Common/Ogc/ObservedProperty.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/ObservedProperty.cs
@@ -1,0 +1,24 @@
+namespace WesternStatesWater.WaDE.Common.Ogc;
+
+/// <summary>
+/// The observedProperty object provides the metadata for the specified query type.
+/// https://docs.ogc.org/is/19-086r6/19-086r6.html#_7e053ab4-5cde-4a5c-a8be-acc6495f9eb5
+/// </summary>
+public class ObservedProperty
+{
+    /// <summary>
+    /// URI linking to an external registry which contains the definitive definition of the observed property
+    /// </summary>
+    public string? Id { get; set; }
+    
+    /// <summary>
+    /// A short text label for the property
+    /// </summary>
+    /// <returns></returns>
+    public required string Label { get; set; }
+    
+    /// <summary>
+    /// A description of the observed property
+    /// </summary>
+    public string? Description { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Common/Ogc/Parameter.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/Parameter.cs
@@ -1,0 +1,48 @@
+namespace WesternStatesWater.WaDE.Common.Ogc;
+
+/// <summary>
+/// Information about the data parameters supported by the collection
+/// https://docs.ogc.org/is/19-086r6/19-086r6.html#_75b53201-11ab-44cd-98eb-b998f32d706e
+/// </summary>
+public class Parameter
+{
+    /// <summary>
+    /// Always 'Parameter'
+    /// </summary>
+    public static string Type => "Parameter";
+
+    /// <summary>
+    /// Parameter Id
+    /// </summary>
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// A short text label for the parameter
+    /// </summary>
+    public string? Label { get; set; }
+
+    /// <summary>
+    /// A description of the parameter
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The data type of the parameter values [integer, float, string]
+    /// </summary>
+    public string? DataType { get; set; }
+
+    /// <summary>
+    /// A formal definition of the parameter
+    /// </summary>
+    public required ObservedProperty ObservedProperty { get; set; }
+
+    /// <summary>
+    /// Information on the spatio-temporal extent of the parameter values (if different from other parameters in the collection)
+    /// </summary>
+    public Unit? Unit { get; set; }
+
+    /// <summary>
+    /// Information on how the value was derived
+    /// </summary>
+    public MeasurementType? MeasurementType { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Common/Ogc/Symbol.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/Symbol.cs
@@ -1,0 +1,28 @@
+namespace WesternStatesWater.WaDE.Common.Ogc;
+
+/// <summary>
+/// The symbol object provides the information to describe the symbols which represent the unit of a value.
+/// </summary>
+public class Symbol
+{
+    /// <summary>
+    /// Symbol name
+    /// </summary>
+    public string? Title { get; set; }
+    
+    /// <summary>
+    /// A text description of the symbol
+    /// </summary>
+    public string? Description { get; set; }
+    
+    /// <summary>
+    /// A Unicode representation for the symbol
+    /// </summary>
+    public string? Value { get; set; }
+    
+    /// <summary>
+    /// A URI to a registry entry providing more detailed information about the unit
+    /// (i.e. QUDT (https://www.qudt.org/) is one example of a registry that provide links for many common units)
+    /// </summary>
+    public string? Type { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Common/Ogc/Unit.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/Unit.cs
@@ -1,0 +1,18 @@
+namespace WesternStatesWater.WaDE.Common.Ogc;
+
+/// <summary>
+/// The unit object provides the information to describe the units of measure of the parameter values.
+/// https://docs.ogc.org/is/19-086r6/19-086r6.html#_5378d779-6a38-4607-9051-6f12c3d3107b
+/// </summary>
+public class Unit
+{
+    /// <summary>
+    /// Name of the unit
+    /// </summary>
+    public string? Label { get; set; }
+    
+    /// <summary>
+    /// Information to describe the symbols used to represent the unit
+    /// </summary>
+    public required Symbol Symbol { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Common/Ogc/Variable.cs
+++ b/source/WesternStatesWater.WaDE.Common/Ogc/Variable.cs
@@ -1,0 +1,63 @@
+namespace WesternStatesWater.WaDE.Common.Ogc;
+
+/// <summary>
+/// The variable object provides fields to describe information that only applies to the owning link.
+/// https://docs.ogc.org/is/19-086r6/19-086r6.html#_1b54f97a-e1dc-4920-b8b4-e4981554138d
+/// </summary>
+public class Variable
+{
+    /// <summary>
+    /// A short text label for the query
+    /// </summary>
+    public string? Title { get; set; }
+    
+    /// <summary>
+    /// A short text label for the query
+    /// </summary>
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// A description of the query
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// One of: position, radius, area, cube, trajectory, corridor, items, locations, instances
+    /// </summary>
+    public string? QueryType { get; set; }
+
+    /// <summary>
+    /// An example of valid coords query parameter values
+    /// </summary>
+    public string? Coords { get; set; }
+
+    /// <summary>
+    /// A list of the valid within units for radius queries
+    /// </summary>
+    public string[]? WithinWidth { get; set; }
+
+    /// <summary>
+    /// A list of the valid width units
+    /// </summary>
+    public string[]? WidthUnits { get; set; }
+
+    /// <summary>
+    /// A list of the valid height units
+    /// </summary>
+    public string[]? HeightUnits { get; set; }
+
+    /// <summary>
+    /// A list of output formats supported by the query, if this field exists it overrides the output formats definition supplied at a collection level.
+    /// </summary>
+    public string[]? OutputFormats { get; set; }
+
+    /// <summary>
+    /// Specifies the default output format for the query
+    /// </summary>
+    public string[]? DefaultOutputFormat { get; set; }
+
+    /// <summary>
+    /// A list of coordinate reference systems supported by the query, if this field exists it overrides the crs values defined at a collection level.
+    /// </summary>
+    public CrsDetail[] CrsDetails { get; set; }
+}

--- a/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcCollectionsFormattingTests.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcCollectionsFormattingTests.cs
@@ -109,7 +109,7 @@ public class OgcCollectionsFormattingTests : OgcFormattingTestBase
                 new Link
                 {
                     Href = $"{ApiHostName}/collections/{collectionId}/items",
-                    Rel = "data",
+                    Rel = "items",
                     Type = "application/geo+json",
                     Title = "Items as GeoJSON"
                 }

--- a/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcCollectionsFormattingTests.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Tests/FormattingEngine/OgcCollectionsFormattingTests.cs
@@ -109,7 +109,7 @@ public class OgcCollectionsFormattingTests : OgcFormattingTestBase
                 new Link
                 {
                     Href = $"{ApiHostName}/collections/{collectionId}/items",
-                    Rel = "items",
+                    Rel = "data",
                     Type = "application/geo+json",
                     Title = "Items as GeoJSON"
                 }

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcConformanceFormattingHandler.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcConformanceFormattingHandler.cs
@@ -13,10 +13,12 @@ public class OgcConformanceFormattingHandler(IConfiguration configuration) : Ogc
         {
             ConformsTo =
             [
-                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
-                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
-                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
-                "http://www.opengis.net/spec/ogcapi-edr-1/1.0/conf/core"
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core", // OGC Features Core
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30", // Open API 3.0
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson", // GeoJSON
+                "http://www.opengis.net/spec/ogcapi-edr-1/1.0/conf/core", // OGC EDR Core
+                "http://www.opengis.net/spec/ogcapi-edr-1/1.0/conf/collections", // OGC EDR Collections
+                "http://www.opengis.net/spec/ogcapi-edr-1/1.0/conf/areas", // OGC EDR Areas
             ]
         });
     }

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcConformanceFormattingHandler.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcConformanceFormattingHandler.cs
@@ -15,7 +15,8 @@ public class OgcConformanceFormattingHandler(IConfiguration configuration) : Ogc
             [
                 "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
                 "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
-                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"
+                "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+                "http://www.opengis.net/spec/ogcapi-edr-1/1.0/conf/core"
             ]
         });
     }

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFeaturesFormattingHandler.cs
@@ -89,7 +89,7 @@ public class OgcFeaturesFormattingHandler(
             new()
             {
                 Href = $"{OgcHost}/collections/{collectionId}/items",
-                Rel = "items",
+                Rel = "data",
                 Type = ContentTypeJson,
                 Title = "The features in this collection"
             },

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
@@ -109,7 +109,7 @@ public abstract class OgcFormattingHandlerBase
                 },
                 new Link
                 {
-                    Href = $"{OgcHost}/collections/{collectionId}/items", Rel = "items",
+                    Href = $"{OgcHost}/collections/{collectionId}/items", Rel = "data",
                     Type = "application/geo+json", Title = "Items as GeoJSON"
                 }
             ],

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
@@ -24,7 +24,7 @@ public abstract class OgcFormattingHandlerBase
         Type = "text/html",
         Title = "Swagger UI"
     };
-    
+
     protected Link ConformanceLink => new Link
     {
         Href = $"{OgcHost}/conformance",
@@ -32,7 +32,7 @@ public abstract class OgcFormattingHandlerBase
         Type = ContentTypeJson,
         Title = "OGC API conformance declaration"
     };
-    
+
     protected Link CollectionsLink => new Link
     {
         Href = $"{OgcHost}/collections",
@@ -40,17 +40,17 @@ public abstract class OgcFormattingHandlerBase
         Type = ContentTypeJson,
         Title = "Resource collections"
     };
-    
+
     /// <summary>
     /// URL to the Swagger file that describes the API.
     /// </summary>
     private string SwaggerDescription { get; }
-    
+
     /// <summary>
     /// URL to the Swagger UI.
     /// </summary>
     private string SwaggerDoc { get; set; }
-    
+
     /// <summary>
     /// Host name that comes from the OgcApi:Host configuration.
     /// Use this when you are referencing links in the OGC API.
@@ -60,15 +60,18 @@ public abstract class OgcFormattingHandlerBase
     protected OgcFormattingHandlerBase(IConfiguration configuration)
     {
         Configuration = configuration;
-        
-        OgcHost = configuration["OgcApi:Host"] ?? 
-                  throw new InvalidOperationException($"{nameof(OgcFormattingHandlerBase)} requires OgcApi:Host configuration to build the specification links.");
-        
-        SwaggerDoc = configuration["OgcApi:SwaggerDoc"] ?? 
-                  throw new InvalidOperationException($"{nameof(OgcFormattingHandlerBase)} requires OgcApi:SwaggerDoc configuration to build the specification links.");
-        
-        SwaggerDescription = configuration["OgcApi:SwaggerDescription"] ?? 
-                  throw new InvalidOperationException($"{nameof(OgcFormattingHandlerBase)} requires OgcApi:SwaggerDescription configuration to build the specification links.");
+
+        OgcHost = configuration["OgcApi:Host"] ??
+                  throw new InvalidOperationException(
+                      $"{nameof(OgcFormattingHandlerBase)} requires OgcApi:Host configuration to build the specification links.");
+
+        SwaggerDoc = configuration["OgcApi:SwaggerDoc"] ??
+                     throw new InvalidOperationException(
+                         $"{nameof(OgcFormattingHandlerBase)} requires OgcApi:SwaggerDoc configuration to build the specification links.");
+
+        SwaggerDescription = configuration["OgcApi:SwaggerDescription"] ??
+                             throw new InvalidOperationException(
+                                 $"{nameof(OgcFormattingHandlerBase)} requires OgcApi:SwaggerDescription configuration to build the specification links.");
     }
 
     /// <summary>
@@ -112,7 +115,9 @@ public abstract class OgcFormattingHandlerBase
             ],
             ItemType = "feature",
             Crs = collectionExtent?.Spatial != null ? [metadata.BoundaryBox.Crs] : null,
-            StorageCrs = collectionExtent?.Spatial != null ? metadata.BoundaryBox.Crs : null
+            StorageCrs = collectionExtent?.Spatial != null ? metadata.BoundaryBox.Crs : null,
+            ParameterNames = GetCollectionParameterNames(metadata),
+            DataQueries = GetCollectionDataQueries(collectionId),
         };
     }
 
@@ -164,6 +169,286 @@ public abstract class OgcFormattingHandlerBase
         {
             Spatial = spatial,
             Temporal = temporal
+        };
+    }
+
+    /// <summary>
+    /// Returns the data queries used in all collections.
+    /// </summary>
+    /// <param name="collectionId">Collection Id</param>
+    /// <returns>Data queries for `area` and `items` in CRS84 detail.</returns>
+    private Dictionary<string, DataQuery> GetCollectionDataQueries(string collectionId)
+    {
+        return new Dictionary<string, DataQuery>
+        {
+            {
+                "area", new DataQuery
+                {
+                    Link = new Link
+                    {
+                        Href = $"{OgcHost}/collections/{collectionId}/area?coords={{coords}}",
+                        Rel = "data",
+                        Templated = true,
+                        Variables = new Variable
+                        {
+                            Title = "Area query",
+                            Description = "Area query",
+                            QueryType = "area",
+                            OutputFormats = ["GeoJSON"],
+                            DefaultOutputFormat = ["GeoJSON"],
+                            CrsDetails =
+                            [
+                                // This defines the WGS 84 (EPSG:4326) coordinate reference system, which is the standard for GPS and geospatial applications.
+                                new CrsDetail
+                                {
+                                    Crs = "CRS84",
+                                    Wkt =
+                                        "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "items", new DataQuery
+                {
+                    Link = new Link
+                    {
+                        Href = $"{OgcHost}/collections/{collectionId}/items",
+                        Rel = "data",
+                        Templated = false,
+                        Variables = new Variable
+                        {
+                            Title = "Items query",
+                            Description = "Items query",
+                            QueryType = "items",
+                            OutputFormats = ["GeoJSON"],
+                            DefaultOutputFormat = ["GeoJSON"],
+                            CrsDetails =
+                            [
+                                // This defines the WGS 84 (EPSG:4326) coordinate reference system, which is the standard for GPS and geospatial applications.
+                                new CrsDetail
+                                {
+                                    Crs = "CRS84",
+                                    Wkt =
+                                        "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+    }
+    
+    private static Dictionary<string, Parameter> GetCollectionParameterNames(MetadataBase metadata)
+    {
+        return metadata switch
+        {
+            SiteMetadata => SiteCollectionParameterNames(),
+            AllocationMetadata => RightCollectionParametersNames(),
+            OverlayMetadata => OverlayCollectionParameterNames(),
+            SiteVariableAmountsMetadata => TimeSeriesCollectionParameterNames(),
+            _ => throw new InvalidOperationException("Unknown metadata type.")
+        };
+    }
+
+    private static Dictionary<string, Parameter> SiteCollectionParameterNames()
+    {
+        return new Dictionary<string, Parameter>
+        {
+            {
+                "siteTypes", new Parameter
+                {
+                    Description = "Comma separated list of site types",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "siteTypes"
+                    }
+                }
+            },
+            {
+                "states", new Parameter
+                {
+                    Description = "Comma separate list of abbreviated states",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "states"
+                    }
+                }
+            },
+            {
+                "waterSourceTypes", new Parameter
+                {
+                    Description = "Comma separated list of water source types",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "waterSourceTypes"
+                    }
+                }
+            }
+        };
+    }
+
+    private static Dictionary<string, Parameter> RightCollectionParametersNames()
+    {
+        return new Dictionary<string, Parameter>
+        {
+            {
+                "allocationUuids", new Parameter
+                {
+                    Description = "Comma separated list of allocation UUIDs",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "allocationUuids"
+                    }
+                }
+            },
+            {
+                "siteUuids", new Parameter
+                {
+                    Description = "Comma separated list of site UUIDs",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "siteUuids"
+                    }
+                }
+            },
+            {
+                "states", new Parameter
+                {
+                    Description = "Comma separated list of abbreviated states",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "states"
+                    }
+                }
+            },
+            {
+                "waterSourceTypes", new Parameter
+                {
+                    Description = "Comma separated list of water source types",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "waterSourceTypes"
+                    }
+                }
+            },
+            {
+                "beneficialUses", new Parameter
+                {
+                    Description = "Comma separated list of beneficial uses",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "beneficialUses"
+                    }
+                }
+            }
+        };
+    }
+
+    private static Dictionary<string, Parameter> OverlayCollectionParameterNames()
+    {
+        return new Dictionary<string, Parameter>
+        {
+            {
+                "overlayUuids", new Parameter
+                {
+                    Description = "Comma separated list of overlay UUIDs",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "overlayUuids"
+                    }
+                }
+            },
+            {
+                "siteUuids", new Parameter
+                {
+                    Description = "Comma separated list of site UUIDs",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "siteUuids"
+                    }
+                }
+            },
+            {
+                "states", new Parameter
+                {
+                    Description = "Comma separated list of abbreviated states",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "states"
+                    }
+                }
+            },
+            {
+                "overlayTypes", new Parameter
+                {
+                    Description = "Comma separated list of overlay types",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "overlayTypes"
+                    }
+                }
+            },
+            {
+                "waterSourceTypes", new Parameter
+                {
+                    Description = "Comma separated list of water source types",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "waterSourceTypes"
+                    }
+                }
+            }
+        };
+    }
+
+    private static Dictionary<string, Parameter> TimeSeriesCollectionParameterNames()
+    {
+        return new Dictionary<string, Parameter>
+        {
+            {
+                "siteUuids", new Parameter
+                {
+                    Description = "Comma separated list of site UUIDs",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "siteUuids"
+                    }
+                }
+            },
+            {
+                "states", new Parameter
+                {
+                    Description = "Comma separated list of abbreviated states",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "states"
+                    }
+                }
+            },
+            {
+                "waterSourceTypes", new Parameter
+                {
+                    Description = "Comma separated list of water source types",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "waterSourceTypes"
+                    }
+                }
+            },
+            {
+                "variableTypes", new Parameter
+                {
+                    Description = "Comma separated list of variable types",
+                    ObservedProperty = new ObservedProperty
+                    {
+                        Label = "variableTypes"
+                    }
+                }
+            }
         };
     }
 }

--- a/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
+++ b/source/WesternStatesWater.WaDE.Engines/Handlers/OgcFormattingHandlerBase.cs
@@ -109,7 +109,7 @@ public abstract class OgcFormattingHandlerBase
                 },
                 new Link
                 {
-                    Href = $"{OgcHost}/collections/{collectionId}/items", Rel = "data",
+                    Href = $"{OgcHost}/collections/{collectionId}/items", Rel = "items",
                     Type = "application/geo+json", Title = "Items as GeoJSON"
                 }
             ],

--- a/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/CollectionMetadataGetRequestHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Tests/Handlers/V2/CollectionMetadataGetRequestHandlerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -24,7 +25,7 @@ public class CollectionMetadataGetRequestHandlerTests
     {
         // Arrange
         var request = new CollectionMetadataGetRequest();
-        
+
         var mockResponse = new CollectionResponse
         {
             Collection = new Collection
@@ -43,12 +44,15 @@ public class CollectionMetadataGetRequestHandlerTests
                         Trs = "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
                     }
                 },
-                Links = [
-                new Link
-                {
-                    Href = "http://localhost/",
-                    Rel = "self",
-                }]
+                Links =
+                [
+                    new Link
+                    {
+                        Href = "http://localhost/",
+                        Rel = "self",
+                    }
+                ],
+                ParameterNames = new Dictionary<string, Parameter>()
             }
         };
         _formattingEngineMock.Arrange(mock =>


### PR DESCRIPTION
The following changes addresses errors raised by the OGC Feature & ERD Validation Tool. Tests were ran from https://cite.opengeospatial.org/teamengine/viewSessions.jsp.

# bounding Box Parameter Definition

For all collections, Features Validation tool is complaining about

>  `A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 14: (Requirement /req/core/fc-bbox-definition)` Expected property 'schema -> minItems' with value 'null' for collections path '/collections/timeSeries/items' but was 'null'. expected object to not be null. 

Their tool is checking `assertNotNull(schema.getMinItems(), String.format(msg, "schema -> minItems", "null", schema.getMinItems()));`, but the [specification](https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameter_bbox) which has min/maxItems as oneOf. We could update our `swagger.json` to set minItems: 4 and maxItems: 6 to appease the validation tool, but this is incorrect as the specification states it should be 4 or 6 items.

![image](https://github.com/user-attachments/assets/e683d153-19e8-4851-a13a-82ac9da824f0)

# time Parameter Definition

The tool is failing `datetime` parameter on the sites and overlay collections.

> Required datetime parameter for collections with path '/collections/sites/items' in OpenAPI document is missing expected object to not be null 

Sites and Overlays do not support temporal filtering and is not specified in the feature collection extent. The [specification](https://docs.ogc.org/is/17-069r4/17-069r4.html#_requirements_class_core) says extent can have spatial and or temporal or neither, but their tool doesn't appear to check the extent before determining if those tests should run.

> A bbox or datetime parameter may be used to select only a subset of the features in the collection (the features that are in the bounding box or time interval). 

[But later they specify datetime SHALL be supported](https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameter_datetime).