### PR TITLE
Water Rights Boundary Box Query Timeout

### DIFF
--- a/source/WaDEApiFunctions/v2/swagger.json
+++ b/source/WaDEApiFunctions/v2/swagger.json
@@ -649,7 +649,7 @@
         "schema": {
           "type": "array",
           "minItems": 4,
-          "maxItems": 4,
+          "maxItems": 6,
           "items": {
             "type": "number"
           }

--- a/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/Extensions/QueryableExtensions.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.EntityFrameworkCore;
 using WesternStatesWater.WaDE.Accessors.Contracts.Api;
 using WesternStatesWater.WaDE.Accessors.Contracts.Api.V2.Requests;
 using WesternStatesWater.WaDE.Accessors.EntityFramework;
@@ -65,17 +64,11 @@ public static class QueryableExtensions
     }
 
     public static IQueryable<AllocationAmountsFact> ApplySearchFilters(this IQueryable<AllocationAmountsFact> query,
-        AllocationSearchRequest filters)
+        AllocationSearchRequest filters, List<long> siteIds)
     {
-        if (filters.GeometrySearch?.Geometry != null && !filters.GeometrySearch.Geometry.IsEmpty)
+        if (siteIds != null && siteIds.Count != 0)
         {
-            query = filters.GeometrySearch.SpatialRelationType switch
-            {
-                SpatialRelationType.Intersects => query.Where(x => x.AllocationBridgeSitesFact.Any(
-                    bridge => (bridge.Site.Geometry.Intersects(filters.GeometrySearch.Geometry)) ||
-                              (bridge.Site.SitePoint.Intersects(filters.GeometrySearch.Geometry)))),
-                _ => query
-            };
+            query = query.Where(x => x.AllocationBridgeSitesFact.Any(bridge => siteIds.Contains(bridge.SiteId)));
         }
 
         if (filters.AllocationUuid != null && filters.AllocationUuid.Any())


### PR DESCRIPTION
Water Rights spatial search on sites is done in a separate query to speed up the response time.

Also fixed bug where bbox maxItems was 4 instead of 6.