### PR TITLE
Omit Query Param Key From Unmatched Params Check

### DIFF
--- a/source/WaDEApiFunctions/Extensions/QueryStringExtensions.cs
+++ b/source/WaDEApiFunctions/Extensions/QueryStringExtensions.cs
@@ -13,7 +13,8 @@ public static class QueryStringExtensions
         var properties = typeof(T).GetProperties();
         var unmatchedParameters = new List<string>();
 
-        foreach (var key in query.AllKeys)
+        // Filter out query string parameter key. This is attached to requests for security, but is not a property of the request.
+        foreach (var key in query.AllKeys.Where(x => !x.Equals("key", StringComparison.OrdinalIgnoreCase)))
         {
             if (properties.All(p => !p.Name.Equals(key, StringComparison.InvariantCultureIgnoreCase)))
             {

--- a/source/WesternStatesWater.WaDE.Integration.Tests/Functions/QueryStringExtensionTests.cs
+++ b/source/WesternStatesWater.WaDE.Integration.Tests/Functions/QueryStringExtensionTests.cs
@@ -13,7 +13,7 @@ public class QueryStringExtensionTests
     {
         // Arrange
         var query = new NameValueCollection();
-        query.Add(nameof(TestRequest.TestIds).ToLower(), "1,2,3"); // Matched, case insensitive
+        query.Add(nameof(TestRequest.TestIds).ToLower(), "1,2,3"); // Matched, case-insensitive
         query.Add("dummy", "dummy"); // Unmatched
 
         // Act
@@ -22,6 +22,24 @@ public class QueryStringExtensionTests
         // Assert
         result.Should().BeTrue();
         unmatchedParams.Should().Contain("dummy");
+    }
+    
+    [DataTestMethod]
+    [DataRow("key")]
+    [DataRow("KEY")]
+    public void IgnoreKeyQueryParameter(string keyParamName)
+    {
+        // Arrange
+        var query = new NameValueCollection();
+        query.Add(keyParamName, "dummy"); // Ignored
+        query.Add(nameof(TestRequest.TestIds).ToLower(), "1,2,3"); // Matched, case-insensitive
+
+        // Act
+        var (result, unmatchedParams) = query.ContainsUnmatchedParameters<TestRequest>();
+
+        // Assert
+        result.Should().BeFalse();
+        unmatchedParams.Should().BeEmpty();
     }
 }
 


### PR DESCRIPTION
When APIM has security api keys turned on, key is provided by query string parameter. We need to omit that query string parameter when checking for unmatched parameters on requests.