### PR TITLE
Rename CVs.RegulatoryStatus to CVs.OverlayStatus

### DIFF
--- a/source/WaDEApiFunctions/v1/WaterAllocation_RegulatoryOverlay.cs
+++ b/source/WaDEApiFunctions/v1/WaterAllocation_RegulatoryOverlay.cs
@@ -86,7 +86,7 @@ namespace WaDEApiFunctions.v1
                     StatutoryEndDate = statutoryEndDate,
                     StartDataPublicationDate = startDataPublicationDate,
                     EndDataPublicationDate = endDataPublicationDate,
-                    RegulatoryStatusCV = regulatoryStatusCV,
+                    OverlayStatusCV = regulatoryStatusCV,
                     Geometry = geometry,
                     State = state
                 },

--- a/source/WaDEApiFunctions/v2/README.md
+++ b/source/WaDEApiFunctions/v2/README.md
@@ -248,7 +248,7 @@ This project contains a set of Azure Functions that implement the OGC API Featur
     "overlayNativeId": "0SWCDb",
     "overlayName": "Border",
     "overlayDescription": "Conserve and develop the natural resources of the state",
-    "regulatoryStatusCv": "Active",
+    "overlayStatusCv": "Active",
     "oversightAgency": "New Mexico Department of Agriculture",
     "statute": null,
     "statuteLink": "https://nmdeptag.nmsu.edu/statutes-and-rules.html",

--- a/source/WaDEImportFunctions/CvData.cs
+++ b/source/WaDEImportFunctions/CvData.cs
@@ -48,7 +48,7 @@ namespace WaDEImportFunctions
                 ("methodtype", "methodtype"),
                 ("nhdnetworkstatus", "nhdnetworkstatus"),
                 ("nhdproduct", "nhdproduct"),
-                ("regulatorystatus", "regulatorystatus"),
+                ("overlaystatus", "overlaystatus"),
                 ("reportingunittype", "reportingunittype"),
                 ("reportyear", "reportyearcv"),
                 ("sitetype", "sitetype"),

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/Overlay.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/Overlay.cs
@@ -5,7 +5,7 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Api
     public class Overlay
     {
         public long OverlayID { get; set; }
-        public string RegulatoryStatusCV { get; set; }
+        public string OverlayStatusCV { get; set; }
         public string OversightAgency { get; set; }
         public string OverlayDescription { get; set; }
         public DateTime StatutoryEffectiveDate { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/OverlayFilters.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/OverlayFilters.cs
@@ -12,7 +12,7 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Api
         public DateTime? StatutoryEndDate { get; set; }
         public DateTime? StartDataPublicationDate { get; set; }
         public DateTime? EndDataPublicationDate { get; set; }
-        public string RegulatoryStatusCV { get; set; }
+        public string OverlayStatusCV { get; set; }
         public Geometry Geometry { get; set; }
         public string State { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Api/V2/OverlaySearchItem.cs
@@ -8,7 +8,7 @@ public class OverlaySearchItem
     public string OverlayNativeId { get; set; }
     public string OverlayName { get; set; }
     public string OverlayDescription { get; set; }
-    public string RegulatoryStatusCv { get; set; }
+    public string OverlayStatusCv { get; set; }
     public string OversightAgency { get; set; }
     public string Statute { get; set; }
     public string StatuteLink { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors.Contracts.Import/Overlay.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Contracts.Import/Overlay.cs
@@ -18,7 +18,7 @@ namespace WesternStatesWater.WaDE.Accessors.Contracts.Import
         public string OverlayDescription { get; set; }
 
         [NullValues("")]
-        public string RegulatoryStatusCV { get; set; }
+        public string OverlayStatusCV { get; set; }
 
         [NullValues("")]
         public string OversightAgency { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/ApiRegulatoryOverlayAccessorTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/ApiRegulatoryOverlayAccessorTests.cs
@@ -27,9 +27,9 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             ReportingUnitsDim reportingUnitsDim;
             using (var db = new WaDEContext(configuration))
             {
-                regulatoryOverlayDim = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlayDim = await OverlayDimBuilder.Load(db);
                 reportingUnitsDim = await ReportingUnitsDimBuilder.Load(db);
-                regulatoryReportingUnitsFact = await RegulatoryReportingUnitsFactBuilder.Load(db,
+                regulatoryReportingUnitsFact = await OverlayReportingUnitsFactBuilder.Load(db,
                     new RegulatoryReportingUnitsFactBuilderOptions
                     {
                         RegulatoryOverlay = regulatoryOverlayDim,
@@ -78,12 +78,12 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             DateDim publicationDate;
             using (var db = new WaDEContext(configuration))
             {
-                regulatoryOverlayDim = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlayDim = await OverlayDimBuilder.Load(db);
                 reportingUnitsDim = await ReportingUnitsDimBuilder.Load(db);
                 publicationDate = await DateDimBuilder.Load(db);
                 publicationDate.Date = DateTime.Parse(dataPublicationDate);
 
-                regulatoryReportingUnitsFact = await RegulatoryReportingUnitsFactBuilder.Load(db,
+                regulatoryReportingUnitsFact = await OverlayReportingUnitsFactBuilder.Load(db,
                     new RegulatoryReportingUnitsFactBuilderOptions
                     {
                         RegulatoryOverlay = regulatoryOverlayDim,

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/ApiWaterAllocationAccessorTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/ApiWaterAllocationAccessorTests.cs
@@ -33,7 +33,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             {
                 allocationAmountsFact = await AllocationAmountsFactBuilder.Load(db);
                 waterSourceDim = await WaterSourcesDimBuilder.Load(db);
-                regulatoryOverlayDim = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlayDim = await OverlayDimBuilder.Load(db);
 
                 siteDim = await SitesDimBuilder.Load(db);
                 await AllocationBridgeSitesFactBuilder.Load(db, new AllocationBridgeSitesFactBuilderOptions
@@ -48,7 +48,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                     WaterSourcesDim = waterSourceDim
                 });
 
-                await RegulatoryOverlayBridgeSitesFactBuilder.Load(db,
+                await OverlayBridgeSitesFactBuilder.Load(db,
                     new RegulatoryOverlayBridgeSitesFactBuilderOptions
                     {
                         SitesDim = siteDim,

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/OverlaySearchHandlerTests.cs
@@ -28,7 +28,7 @@ public class OverlaySearchHandlerTests : DbTestBase
 
         for (var i = 0; i < 5; i++)
         {
-            await RegulatoryOverlayDimBuilder.Load(db);
+            await OverlayDimBuilder.Load(db);
         }
 
         var request = new OverlaySearchRequest
@@ -53,7 +53,7 @@ public class OverlaySearchHandlerTests : DbTestBase
         List<OverlayDim> dbOverlays = new();
         for (var i = 0; i < 5; i++)
         {
-            dbOverlays.Add(await RegulatoryOverlayDimBuilder.Load(db));
+            dbOverlays.Add(await OverlayDimBuilder.Load(db));
         }
 
         var request = new OverlaySearchRequest
@@ -80,7 +80,7 @@ public class OverlaySearchHandlerTests : DbTestBase
         List<OverlayDim> overlays = new();
         for (var i = 0; i < 10; i++)
         {
-            overlays.Add(await RegulatoryOverlayDimBuilder.Load(db));
+            overlays.Add(await OverlayDimBuilder.Load(db));
         }
 
         overlays.Sort((x, y) =>
@@ -105,9 +105,9 @@ public class OverlaySearchHandlerTests : DbTestBase
     public async Task Handler_FilterOverlayUuid_ReturnsRequestedOverlays()
     {
         await using var db = new WaDEContext(Configuration.GetConfiguration());
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayB = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayC = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
+        var overlayB = await OverlayDimBuilder.Load(db);
+        var overlayC = await OverlayDimBuilder.Load(db);
 
         var request = new OverlaySearchRequest
         {
@@ -132,22 +132,22 @@ public class OverlaySearchHandlerTests : DbTestBase
         var siteA = await SitesDimBuilder.Load(db);
         var siteB = await SitesDimBuilder.Load(db);
 
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayB = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
+        var overlayB = await OverlayDimBuilder.Load(db);
 
-        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
+        await OverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
         {
             SitesDim = siteA,
             RegulatoryOverlayDim = overlayA
         });
 
-        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
+        await OverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
         {
             SitesDim = siteB,
             RegulatoryOverlayDim = overlayB
         });
 
-        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions());
+        await OverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions());
 
         var request = new OverlaySearchRequest
         {
@@ -184,23 +184,23 @@ public class OverlaySearchHandlerTests : DbTestBase
             Geometry = CreateGreatSaltLakeGeometry()
         });
 
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayB = await RegulatoryOverlayDimBuilder.Load(db);
-        var omittedOverlay = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
+        var overlayB = await OverlayDimBuilder.Load(db);
+        var omittedOverlay = await OverlayDimBuilder.Load(db);
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaInersectingRequest
         });
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayB,
             ReportingUnits = areaInsideRequest
         });
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = omittedOverlay,
             ReportingUnits = areaOutsideRequest
@@ -257,21 +257,21 @@ public class OverlaySearchHandlerTests : DbTestBase
             Geometry = polygonC
         });
 
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaA
         });
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaB
         });
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaC
@@ -322,22 +322,22 @@ public class OverlaySearchHandlerTests : DbTestBase
             Geometry = polygonC
         });
 
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
 
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaA
         });
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaB
         });
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaC
@@ -387,22 +387,22 @@ public class OverlaySearchHandlerTests : DbTestBase
             Geometry = polygonC
         });
 
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
 
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaA
         });
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaB
         });
 
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaC
@@ -447,20 +447,20 @@ public class OverlaySearchHandlerTests : DbTestBase
             State = stateA
         });
 
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayB = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
+        var overlayB = await OverlayDimBuilder.Load(db);
         
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaA
         });
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayB,
             ReportingUnits = areaB
         });
-        await RegulatoryReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
+        await OverlayReportingUnitsFactBuilder.Load(db, new RegulatoryReportingUnitsFactBuilderOptions
         {
             RegulatoryOverlay = overlayA,
             ReportingUnits = areaC
@@ -487,9 +487,9 @@ public class OverlaySearchHandlerTests : DbTestBase
         // Arrange
         await using var db = new WaDEContext(Configuration.GetConfiguration());
 
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayB = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayC = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
+        var overlayB = await OverlayDimBuilder.Load(db);
+        var overlayC = await OverlayDimBuilder.Load(db);
 
         string[] uniqueOverlayTypes =
             [overlayA.OverlayType.WaDEName, overlayB.OverlayType.WaDEName, overlayC.OverlayType.WaDEName];
@@ -516,9 +516,9 @@ public class OverlaySearchHandlerTests : DbTestBase
         // Arrange
         await using var db = new WaDEContext(Configuration.GetConfiguration());
 
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayB = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayC = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
+        var overlayB = await OverlayDimBuilder.Load(db);
+        var overlayC = await OverlayDimBuilder.Load(db);
 
         string[] uniqueWaterSourceTypes =
             [overlayA.WaterSourceType.WaDEName, overlayB.WaterSourceType.WaDEName, overlayC.WaterSourceType.WaDEName];

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/SiteSearchHandlerTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/Handlers/SiteSearchHandlerTests.cs
@@ -218,16 +218,16 @@ public class SiteSearchHandlerTests : DbTestBase
             WaterSourcesDim = sourceB
         });
         
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayB = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
+        var overlayB = await OverlayDimBuilder.Load(db);
         
-        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
+        await OverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
         {
             SitesDim = siteA,
             RegulatoryOverlayDim = overlayA
         });
         
-        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
+        await OverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
         {
             SitesDim = siteA,
             RegulatoryOverlayDim = overlayB
@@ -390,19 +390,19 @@ public class SiteSearchHandlerTests : DbTestBase
     {
         await using var db = new WaDEContext(Configuration.GetConfiguration());
         
-        var overlayA = await RegulatoryOverlayDimBuilder.Load(db);
-        var overlayB = await RegulatoryOverlayDimBuilder.Load(db);
+        var overlayA = await OverlayDimBuilder.Load(db);
+        var overlayB = await OverlayDimBuilder.Load(db);
         
         var siteA = await SitesDimBuilder.Load(db);
         var siteB = await SitesDimBuilder.Load(db);
         
-        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
+        await OverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
         {
             SitesDim = siteA,
             RegulatoryOverlayDim = overlayA
         });
         
-        await RegulatoryOverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
+        await OverlayBridgeSitesFactBuilder.Load(db, new RegulatoryOverlayBridgeSitesFactBuilderOptions
         {
             SitesDim = siteB,
             RegulatoryOverlayDim = overlayB

--- a/source/WesternStatesWater.WaDE.Accessors.Tests/ImportDataIngestionAccessorTests.cs
+++ b/source/WesternStatesWater.WaDE.Accessors.Tests/ImportDataIngestionAccessorTests.cs
@@ -1165,7 +1165,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
                 organization = await OrganizationsDimBuilder.Load(db);
-                regulatoryOverlay = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay = await OverlayDimBuilder.Load(db);
                 reportingUnit = await ReportingUnitsDimBuilder.Load(db);
                 date = await DateDimBuilder.Load(db);
 
@@ -1215,7 +1215,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                     SiteTypeCvNavigation = await SiteTypeBuilder.Load(db),
                     StateCVNavigation = await StateBuilder.Load(db)
                 });
-                regulatoryOverlay = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay = await OverlayDimBuilder.Load(db);
 
                 site = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1255,7 +1255,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
                 siteDim = await SitesDimBuilder.Load(db);
-                regulatoryOverlay = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay = await OverlayDimBuilder.Load(db);
 
                 site = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1304,7 +1304,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                     SiteTypeCvNavigation = await SiteTypeBuilder.Load(db),
                     StateCVNavigation = await StateBuilder.Load(db)
                 });
-                regulatoryOverlay = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay = await OverlayDimBuilder.Load(db);
 
                 site = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1346,8 +1346,8 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
                 siteDim = await SitesDimBuilder.Load(db);
-                regulatoryOverlay1 = await RegulatoryOverlayDimBuilder.Load(db);
-                regulatoryOverlay2 = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay1 = await OverlayDimBuilder.Load(db);
+                regulatoryOverlay2 = await OverlayDimBuilder.Load(db);
 
                 site = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1391,8 +1391,8 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
                 siteDim = await SitesDimBuilder.Load(db);
-                regulatoryOverlay1 = await RegulatoryOverlayDimBuilder.Load(db);
-                regulatoryOverlay2 = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay1 = await OverlayDimBuilder.Load(db);
+                regulatoryOverlay2 = await OverlayDimBuilder.Load(db);
 
                 site = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1429,7 +1429,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
 
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
-                regulatoryOverlay3 = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay3 = await OverlayDimBuilder.Load(db);
 
                 updatedSite = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1477,8 +1477,8 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
                 siteDim = await SitesDimBuilder.Load(db);
-                regulatoryOverlay1 = await RegulatoryOverlayDimBuilder.Load(db);
-                regulatoryOverlay2 = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay1 = await OverlayDimBuilder.Load(db);
+                regulatoryOverlay2 = await OverlayDimBuilder.Load(db);
 
                 site = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1515,7 +1515,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
 
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
-                regulatoryOverlay3 = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay3 = await OverlayDimBuilder.Load(db);
 
                 updatedSite = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1558,8 +1558,8 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
                 siteDim = await SitesDimBuilder.Load(db);
-                regulatoryOverlay1 = await RegulatoryOverlayDimBuilder.Load(db);
-                regulatoryOverlay2 = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay1 = await OverlayDimBuilder.Load(db);
+                regulatoryOverlay2 = await OverlayDimBuilder.Load(db);
 
                 site = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1654,8 +1654,8 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             {
                 siteDim = await SitesDimBuilder.Load(db);
                 regulatoryOverlays = new List<OverlayDim>{
-                    await RegulatoryOverlayDimBuilder.Load(db),
-                    await RegulatoryOverlayDimBuilder.Load(db)
+                    await OverlayDimBuilder.Load(db),
+                    await OverlayDimBuilder.Load(db)
                 };
 
                 site = SiteBuilder.Create(new SiteBuilderOptions()
@@ -1690,7 +1690,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
                 siteDim1 = await SitesDimBuilder.Load(db);
-                regulatoryOverlay1 = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay1 = await OverlayDimBuilder.Load(db);
 
                 site1 = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1711,7 +1711,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
                 siteDim2 = await SitesDimBuilder.Load(db);
-                regulatoryOverlay2 = await RegulatoryOverlayDimBuilder.Load(db);
+                regulatoryOverlay2 = await OverlayDimBuilder.Load(db);
 
                 site2 = SiteBuilder.Create(new SiteBuilderOptions()
                 {
@@ -1852,20 +1852,20 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
         public async Task LoadRegulatoryOverlays_SimpleLoad()
         {
             OverlayTypeCV organization;
-            RegulatoryStatus regulatoryStatus;
+            OverlayStatus overlayStatus;
             WaterSourceType waterSourceType;
             Overlay regulatoryOverlay;
 
             using (var db = new WaDEContext(Configuration.GetConfiguration()))
             {
-                organization = await RegulatoryOverlayTypeBuilder.Load(db);
-                regulatoryStatus = await RegulatoryStatusBuilder.Load(db);
+                organization = await OverlayTypeBuilder.Load(db);
+                overlayStatus = await OverlayStatusBuilder.Load(db);
                 waterSourceType = await WaterSourceTypeBuilder.Load(db);
 
                 regulatoryOverlay = OverlayBuilder.Create(new OverlayBuilderOptions
                 {
-                    RegulatoryOverlayType = organization,
-                    RegulatoryStatus = regulatoryStatus,
+                    OverlayType = organization,
+                    OverlayStatus = overlayStatus,
                     WaterSourceType = waterSourceType
                 });
             }
@@ -1884,7 +1884,7 @@ namespace WesternStatesWater.WaDE.Accessors.Tests
                 dbRegulatoryOverlay.OverlayNativeId.Should().Be(regulatoryOverlay.OverlayNativeID);
                 dbRegulatoryOverlay.OverlayName.Should().Be(regulatoryOverlay.OverlayName);
                 dbRegulatoryOverlay.OverlayDescription.Should().Be(regulatoryOverlay.OverlayDescription);
-                dbRegulatoryOverlay.RegulatoryStatusCv.Should().Be(regulatoryOverlay.RegulatoryStatusCV);
+                dbRegulatoryOverlay.OverlayStatusCv.Should().Be(regulatoryOverlay.OverlayStatusCV);
                 dbRegulatoryOverlay.OversightAgency.Should().Be(regulatoryOverlay.OversightAgency);
                 dbRegulatoryOverlay.Statute.Should().Be(regulatoryOverlay.Statute);
                 dbRegulatoryOverlay.StatuteLink.Should().Be(regulatoryOverlay.StatuteLink);

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/OverlayDim.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/OverlayDim.cs
@@ -15,7 +15,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public string OverlayNativeId { get; set; }
         public string OverlayName { get; set; }
         public string OverlayDescription { get; set; }
-        public string RegulatoryStatusCv { get; set; }
+        public string OverlayStatusCv { get; set; }
         public string OversightAgency { get; set; }
         public string Statute { get; set; }
         public string StatuteLink { get; set; }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/OverlayStatus.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/OverlayStatus.cs
@@ -1,6 +1,6 @@
 ﻿namespace WesternStatesWater.WaDE.Accessors.EntityFramework
 {
-    public partial class RegulatoryStatus : ControlledVocabularyBase
+    public partial class OverlayStatus : ControlledVocabularyBase
     {
     }
 }

--- a/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/EntityFramework/WaDEContext.cs
@@ -42,7 +42,7 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
         public virtual DbSet<OverlayTypeCV> OverlayType { get; set; }
         public virtual DbSet<OverlayReportingUnitsFact> OverlayReportingUnitsFact { get; set; }
         public virtual DbSet<OverlayBridgeSitesFact> OverlayBridgeSitesFact { get; set; }
-        public virtual DbSet<RegulatoryStatus> RegulatoryStatus { get; set; }
+        public virtual DbSet<OverlayStatus> OverlayStatus { get; set; }
         public virtual DbSet<ReportYearCv> ReportYearCv { get; set; }
         public virtual DbSet<ReportYearType> ReportYearType { get; set; }
         public virtual DbSet<ReportingUnitType> ReportingUnitType { get; set; }
@@ -1112,9 +1112,9 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                     .HasColumnName("OverlayUUID")
                     .HasMaxLength(250);
 
-                entity.Property(e => e.RegulatoryStatusCv)
+                entity.Property(e => e.OverlayStatusCv)
                     .IsRequired()
-                    .HasColumnName("RegulatoryStatusCV")
+                    .HasColumnName("OverlayStatusCV")
                     .HasMaxLength(50);
 
                 entity.Property(e => e.OverlayTypeCV)
@@ -1238,12 +1238,12 @@ namespace WesternStatesWater.WaDE.Accessors.EntityFramework
                     .HasConstraintName("fk_RegulatoryOverLayBridge_Sites_fact_Sites_dim");
             });
 
-            modelBuilder.Entity<RegulatoryStatus>(entity =>
+            modelBuilder.Entity<OverlayStatus>(entity =>
             {
                 entity.HasKey(e => e.Name)
                     .HasName("pkRegulatoryStatus");
 
-                entity.ToTable("RegulatoryStatus", "CVs");
+                entity.ToTable("OverlayStatus", "CVs");
 
                 entity.Property(e => e.Name)
                     .HasMaxLength(250)

--- a/source/WesternStatesWater.WaDE.Accessors/RegulatoryOverlayAccessor.cs
+++ b/source/WesternStatesWater.WaDE.Accessors/RegulatoryOverlayAccessor.cs
@@ -124,9 +124,9 @@ namespace WesternStatesWater.WaDE.Accessors
                 query = query.Where(a => a.Overlay.OverlayUuid == filters.OverlayUUID);
             }
 
-            if (!string.IsNullOrWhiteSpace(filters.RegulatoryStatusCV))
+            if (!string.IsNullOrWhiteSpace(filters.OverlayStatusCV))
             {
-                query = query.Where(a => a.Overlay.RegulatoryStatusCv == filters.RegulatoryStatusCV);
+                query = query.Where(a => a.Overlay.OverlayStatusCv == filters.OverlayStatusCV);
             }
 
             if (!string.IsNullOrWhiteSpace(filters.ReportingUnitUUID))

--- a/source/WesternStatesWater.WaDE.Contracts.Api/OverlayFilters.cs
+++ b/source/WesternStatesWater.WaDE.Contracts.Api/OverlayFilters.cs
@@ -11,7 +11,7 @@ namespace WesternStatesWater.WaDE.Contracts.Api
         public DateTime? StatutoryEndDate { get; set; }
         public DateTime? StartDataPublicationDate { get; set; }
         public DateTime? EndDataPublicationDate { get; set; }
-        public string RegulatoryStatusCV { get; set; }
+        public string OverlayStatusCV { get; set; }
         public string Geometry { get; set; }
         public string State { get; set; }
     }

--- a/source/WesternStatesWater.WaDE.DbUp/Scripts/007/014 RenameRegulatoryStatusTable.sql
+++ b/source/WesternStatesWater.WaDE.DbUp/Scripts/007/014 RenameRegulatoryStatusTable.sql
@@ -1,0 +1,119 @@
+EXEC sp_rename 'Core.Overlay_dim.RegulatoryStatusCV', 'OverlayStatusCV', 'COLUMN';
+
+CREATE TYPE [Core].[OverlayTableType_new] AS TABLE(
+    [OverlayUUID] [nvarchar](250) NULL,
+    [OverlayNativeID] [nvarchar](250) NULL,
+    [OverlayName] [nvarchar](50) NULL,
+    [OverlayDescription] [nvarchar](max) NULL,
+    [OverlayStatusCV] [nvarchar](50) NULL,
+    [OversightAgency] [nvarchar](250) NULL,
+    [Statute] [nvarchar](500) NULL,
+    [StatuteLink] [nvarchar](500) NULL,
+    [StatutoryEffectiveDATE] [date] NULL,
+    [StatutoryEndDATE] [date] NULL,
+    [OverlayTypeCV] [nvarchar](100) NULL,
+    [WaterSourceTypeCV] [nvarchar](100) NULL
+)
+GO
+
+EXEC Core.UpdateUUDT 'Core', 'OverlayTableType';
+GO
+
+/************************************************************************************/
+
+ALTER PROCEDURE [Core].[LoadOverlays]
+(
+    @RunId NVARCHAR(250),
+    @OverlayTable Core.OverlayTableType READONLY
+)
+AS
+BEGIN
+SELECT ROW_NUMBER() OVER(ORDER BY (SELECT NULL)) RowNumber, *
+INTO #TempOverlayData
+FROM @OverlayTable;
+
+--data validation
+WITH q1 AS
+         (
+             SELECT 'OverlayUUID Not Valid' Reason, *
+             FROM #TempOverlayData
+             WHERE OverlayUUID IS NULL
+             UNION ALL
+             SELECT 'OverlayName Not Valid' Reason, *
+             FROM #TempOverlayData
+             WHERE OverlayName IS NULL
+             UNION ALL
+             SELECT 'OverlayDescription Not Valid' Reason, *
+             FROM #TempOverlayData
+             WHERE OverlayDescription IS NULL
+             UNION ALL
+             SELECT 'OverlayStatusCV Not Valid' Reason, *
+             FROM #TempOverlayData
+             WHERE OverlayStatusCV IS NULL
+             UNION ALL
+             SELECT 'OversightAgency Not Valid' Reason, *
+             FROM #TempOverlayData
+             WHERE OversightAgency IS NULL
+             UNION ALL
+             SELECT 'StatutoryEffectiveDate Not Valid' Reason, *
+             FROM #TempOverlayData
+             WHERE StatutoryEffectiveDate IS NULL
+         )
+SELECT * INTO #TempErrorOverlayRecords FROM q1;
+
+--if we have errors, insert them and bail out
+IF EXISTS(SELECT 1 FROM #TempErrorOverlayRecords)
+BEGIN
+INSERT INTO Core.ImportErrors ([Type], [RunId], [Data])
+VALUES ('Overlays', @RunId, (SELECT * FROM #TempErrorOverlayRecords FOR JSON PATH));
+RETURN 1;
+END
+
+--merge into Core.Overlay_dim
+MERGE INTO Core.Overlay_dim AS Target USING #TempOverlayData AS Source ON
+    Target.OverlayUUID = Source.OverlayUUID
+    WHEN MATCHED THEN
+        UPDATE SET
+            OverlayNativeID = Source.OverlayNativeID
+            ,OverlayName = Source.OverlayName
+            ,OverlayDescription = Source.OverlayDescription
+            ,OverlayStatusCV = Source.OverlayStatusCV
+            ,OversightAgency = Source.OversightAgency
+            ,Statute = Source.Statute
+            ,StatuteLink = Source.StatuteLink
+            ,StatutoryEffectiveDate = Source.StatutoryEffectiveDate
+            ,StatutoryEndDate = Source.StatutoryEndDate
+    WHEN NOT MATCHED THEN
+        INSERT
+            (OverlayUUID
+                ,OverlayNativeID
+                ,OverlayName
+                ,OverlayDescription
+                ,OverlayStatusCV
+                ,OversightAgency
+                ,Statute
+                ,StatuteLink
+                ,StatutoryEffectiveDate
+                ,StatutoryEndDate
+                ,OverlayTypeCV
+                ,WaterSourceTypeCV)
+            VALUES
+                (Source.OverlayUUID
+                ,Source.OverlayNativeID
+                ,Source.OverlayName
+                ,Source.OverlayDescription
+                ,Source.OverlayStatusCV
+                ,Source.OversightAgency
+                ,Source.Statute
+                ,Source.StatuteLink
+                ,Source.StatutoryEffectiveDate
+                ,Source.StatutoryEndDate
+                ,Source.OverlayTypeCV
+                ,Source.WaterSourceTypeCV);
+RETURN 0;
+END
+GO
+
+/************************************************************************************/
+
+EXEC sp_rename 'CVs.RegulatoryStatus', 'OverlayStatus';

--- a/source/WesternStatesWater.WaDE.Engines.Contracts/OverlayFeature.cs
+++ b/source/WesternStatesWater.WaDE.Engines.Contracts/OverlayFeature.cs
@@ -6,7 +6,7 @@ public class OverlayFeature : FeatureBase
     public string OverlayNativeId { get; set; }
     public string OverlayName { get; set; }
     public string OverlayDescription { get; set; }
-    public string RegulatoryStatusCv { get; set; }
+    public string OverlayStatusCv { get; set; }
     public string OversightAgency { get; set; }
     public string Statute { get; set; }
     public string StatuteLink { get; set; }

--- a/source/WesternStatesWater.WaDE.Managers.Api/Mapping/ApiProfile.cs
+++ b/source/WesternStatesWater.WaDE.Managers.Api/Mapping/ApiProfile.cs
@@ -55,7 +55,8 @@ namespace WesternStatesWater.WaDE.Managers.Api.Mapping
                 .ForMember(dest => dest.RegulatoryOverlayUUID, opt => opt.MapFrom(src => src.OverlayUUID))
                 .ForMember(dest => dest.RegulatoryDescription, opt => opt.MapFrom(src => src.OverlayDescription))
                 .ForMember(dest => dest.RegulatoryOverlayTypeCV, opt => opt.MapFrom(src => src.OverlayTypeCV))
-                .ForMember(dest => dest.RegulatoryStatuteLink, opt => opt.MapFrom(src => src.StatuteLink));
+                .ForMember(dest => dest.RegulatoryStatuteLink, opt => opt.MapFrom(src => src.StatuteLink))
+                .ForMember(dest => dest.RegulatoryStatusCV, opt => opt.MapFrom(src => src.OverlayStatusCV));
             CreateMap<AccessorApi.ReportingUnitOverlay, ManagerApi.ReportingUnitRegulatory>();
 
             CreateMap<AccessorApi.OverlayReportingUnits, ManagerApi.RegulatoryReportingUnits>();

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Api/RegulatoryOverlayBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Api/RegulatoryOverlayBuilder.cs
@@ -10,7 +10,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Api
         {
             var faker = new Faker<Overlay>()
                 .RuleFor(a => a.OverlayID, f => f.Random.Long(1))
-                .RuleFor(a => a.RegulatoryStatusCV, f => f.Random.Word(50))
+                .RuleFor(a => a.OverlayStatusCV, f => f.Random.Word(50))
                 .RuleFor(a => a.OversightAgency, f => f.Company.CompanyName())
                 .RuleFor(a => a.OverlayDescription, f => f.Lorem.Sentence())
                 .RuleFor(a => a.StatutoryEffectiveDate, f => f.Date.Past(100))

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/OverlayBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/Accessor/Import/OverlayBuilder.cs
@@ -18,13 +18,13 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Import
                 .RuleFor(a => a.OverlayNativeID, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.OverlayName, f => f.Company.CompanyName())
                 .RuleFor(a => a.OverlayDescription, f => f.Rant.ToString())
-                .RuleFor(a => a.RegulatoryStatusCV, f => opts?.RegulatoryStatus?.Name ?? f.Random.Word())
+                .RuleFor(a => a.OverlayStatusCV, f => opts?.OverlayStatus?.Name ?? f.Random.Word())
                 .RuleFor(a => a.OversightAgency, f => f.Company.CompanyName())
                 .RuleFor(a => a.Statute, f => f.Random.Word())
                 .RuleFor(a => a.StatuteLink, f => f.Internet.Url())
                 .RuleFor(a => a.StatutoryEffectiveDate, f => f.Date.Past(10))
                 .RuleFor(a => a.StatutoryEndDate, f => f.Date.Past(5))
-                .RuleFor(a => a.OverlayTypeCV, f => opts?.RegulatoryOverlayType?.Name ?? f.Random.AlphaNumeric(10))
+                .RuleFor(a => a.OverlayTypeCV, f => opts?.OverlayType?.Name ?? f.Random.AlphaNumeric(10))
                 .RuleFor(a => a.WaterSourceTypeCV, f => opts?.WaterSourceType?.Name ?? f.Random.AlphaNumeric(10));
 
             return faker;
@@ -33,8 +33,8 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.Accessor.Import
 
     public class OverlayBuilderOptions
     {
-        public RegulatoryStatus RegulatoryStatus { get; set; }
-        public OverlayTypeCV RegulatoryOverlayType { get; set; }
+        public OverlayStatus OverlayStatus { get; set; }
+        public OverlayTypeCV OverlayType { get; set; }
         public WaterSourceType WaterSourceType { get; set; }
     }
 }

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayBridgeSitesFactBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayBridgeSitesFactBuilder.cs
@@ -4,7 +4,7 @@ using WesternStatesWater.WaDE.Accessors.EntityFramework;
 
 namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
-    public class RegulatoryOverlayBridgeSitesFactBuilder
+    public class OverlayBridgeSitesFactBuilder
     {
         public static OverlayBridgeSitesFact Create()
         {
@@ -15,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         {
             var faker = new Faker<OverlayBridgeSitesFact>()
                 .RuleFor(a => a.SiteId, f => opts.SitesDim?.SiteId ?? SitesDimBuilder.GenerateId())
-                .RuleFor(a => a.OverlayId, f => opts.RegulatoryOverlayDim?.OverlayId ?? RegulatoryOverlayDimBuilder.GenerateId())
+                .RuleFor(a => a.OverlayId, f => opts.RegulatoryOverlayDim?.OverlayId ?? OverlayDimBuilder.GenerateId())
                 ;
 
             return faker;
@@ -29,7 +29,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static async Task<OverlayBridgeSitesFact> Load(WaDEContext db, RegulatoryOverlayBridgeSitesFactBuilderOptions opts)
         {
             opts.SitesDim = opts.SitesDim ?? await SitesDimBuilder.Load(db);
-            opts.RegulatoryOverlayDim = opts.RegulatoryOverlayDim ?? await RegulatoryOverlayDimBuilder.Load(db);
+            opts.RegulatoryOverlayDim = opts.RegulatoryOverlayDim ?? await OverlayDimBuilder.Load(db);
             
             var item = Create(opts);
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayDimBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayDimBuilder.cs
@@ -4,7 +4,7 @@ using WesternStatesWater.WaDE.Accessors.EntityFramework;
 
 namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
-    public static class RegulatoryOverlayDimBuilder
+    public static class OverlayDimBuilder
     {
         public static OverlayDim Create()
         {
@@ -18,13 +18,13 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.OverlayNativeId, f => f.Random.Uuid().ToString())
                 .RuleFor(a => a.OverlayName, f => f.Company.CompanyName())
                 .RuleFor(a => a.OverlayDescription, f => f.Rant.ToString())
-                .RuleFor(a => a.RegulatoryStatusCv, f => opts?.RegulatoryStatus?.Name ?? RegulatoryStatusBuilder.GenerateName())
+                .RuleFor(a => a.OverlayStatusCv, f => opts?.OverlayStatus?.Name ?? OverlayStatusBuilder.GenerateName())
                 .RuleFor(a => a.OversightAgency, f => f.Company.CompanyName())
                 .RuleFor(a => a.Statute, f => f.Random.Word())
                 .RuleFor(a => a.StatuteLink, f => f.Internet.Url())
                 .RuleFor(a => a.StatutoryEffectiveDate, f => f.Date.Past(10))
                 .RuleFor(a => a.StatutoryEndDate, f => f.Date.Past(5))
-                .RuleFor(a => a.OverlayTypeCV, f => opts?.RegulatoryOverlayType?.Name ?? RegulatoryOverlayTypeBuilder.GenerateName())
+                .RuleFor(a => a.OverlayTypeCV, f => opts?.OverlayType?.Name ?? OverlayTypeBuilder.GenerateName())
                 .RuleFor(a => a.WaterSourceTypeCV, f => opts?.WaterSourceType?.Name ?? WaterSourceTypeBuilder.GenerateName());
         }
 
@@ -37,8 +37,8 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         {
             opts = opts ?? new RegulatoryOverlayDimBuilderOptions();
 
-            opts.RegulatoryStatus = opts.RegulatoryStatus ?? await RegulatoryStatusBuilder.Load(db);
-            opts.RegulatoryOverlayType = opts.RegulatoryOverlayType ?? await RegulatoryOverlayTypeBuilder.Load(db);
+            opts.OverlayStatus = opts.OverlayStatus ?? await OverlayStatusBuilder.Load(db);
+            opts.OverlayType = opts.OverlayType ?? await OverlayTypeBuilder.Load(db);
             opts.WaterSourceType = opts.WaterSourceType ?? await WaterSourceTypeBuilder.Load(db);
 
             var item = Create(opts);
@@ -57,8 +57,8 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 
     public class RegulatoryOverlayDimBuilderOptions
     {
-        public RegulatoryStatus RegulatoryStatus { get; set; }
-        public OverlayTypeCV RegulatoryOverlayType { get; set; }
+        public OverlayStatus OverlayStatus { get; set; }
+        public OverlayTypeCV OverlayType { get; set; }
         public WaterSourceType WaterSourceType { get; set; }
     }
 }

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayReportingUnitsFactBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayReportingUnitsFactBuilder.cs
@@ -4,7 +4,7 @@ using WesternStatesWater.WaDE.Accessors.EntityFramework;
 
 namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
-    public static class RegulatoryReportingUnitsFactBuilder
+    public static class OverlayReportingUnitsFactBuilder
     {
         public static OverlayReportingUnitsFact Create()
         {
@@ -15,7 +15,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         {
             return new Faker<OverlayReportingUnitsFact>()
                 .RuleFor(a => a.OrganizationId, f => opts.OrganizationsDim?.OrganizationId ?? OrganizationsDimBuilder.GenerateId())
-                .RuleFor(a => a.OverlayId, f => opts.RegulatoryOverlay?.OverlayId ?? RegulatoryOverlayDimBuilder.GenerateId())
+                .RuleFor(a => a.OverlayId, f => opts.RegulatoryOverlay?.OverlayId ?? OverlayDimBuilder.GenerateId())
                 .RuleFor(a => a.ReportingUnitId, f => opts.ReportingUnits?.ReportingUnitId ?? ReportingUnitsDimBuilder.GenerateId())
                 .RuleFor(a => a.DataPublicationDateId, f => opts.DataPublicationDate?.DateId ?? DateDimBuilder.GenerateId());
         }
@@ -28,7 +28,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         public static async Task<OverlayReportingUnitsFact> Load(WaDEContext db, RegulatoryReportingUnitsFactBuilderOptions opts)
         {
             opts.OrganizationsDim ??= await OrganizationsDimBuilder.Load(db);
-            opts.RegulatoryOverlay ??= await RegulatoryOverlayDimBuilder.Load(db);
+            opts.RegulatoryOverlay ??= await OverlayDimBuilder.Load(db);
             opts.ReportingUnits ??= await ReportingUnitsDimBuilder.Load(db);
             opts.DataPublicationDate ??= await DateDimBuilder.Load(db);
 

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayStatusBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayStatusBuilder.cs
@@ -4,17 +4,17 @@ using WesternStatesWater.WaDE.Accessors.EntityFramework;
 
 namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
-    public static class RegulatoryStatusBuilder
+    public static class OverlayStatusBuilder
     {
         private static int _globalIndex = 0;
-        public static RegulatoryStatus Create()
+        public static OverlayStatus Create()
         {
-            return Create(new RegulatoryStatusBuilderOptions());
+            return Create(new OverlayStatusBuilderOptions());
         }
 
-        public static RegulatoryStatus Create(RegulatoryStatusBuilderOptions opts)
+        public static OverlayStatus Create(OverlayStatusBuilderOptions opts)
         {
-            return new Faker<RegulatoryStatus>()
+            return new Faker<OverlayStatus>()
                 .RuleFor(a => a.Name, f => GenerateName())
                 .RuleFor(a => a.Term, f => f.Random.Word())
                 .RuleFor(a => a.Definition, f => f.Random.Words(5))
@@ -22,16 +22,16 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
                 .RuleFor(a => a.SourceVocabularyUri, f => f.Internet.Url());
         }
 
-        public static async Task<RegulatoryStatus> Load(WaDEContext db)
+        public static async Task<OverlayStatus> Load(WaDEContext db)
         {
-            return await Load(db, new RegulatoryStatusBuilderOptions());
+            return await Load(db, new OverlayStatusBuilderOptions());
         }
 
-        public static async Task<RegulatoryStatus> Load(WaDEContext db, RegulatoryStatusBuilderOptions opts)
+        public static async Task<OverlayStatus> Load(WaDEContext db, OverlayStatusBuilderOptions opts)
         {
             var item = Create(opts);
 
-            db.RegulatoryStatus.Add(item);
+            db.OverlayStatus.Add(item);
             await db.SaveChangesAsync();
 
             return item;
@@ -44,7 +44,7 @@ namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
         }
     }
 
-    public class RegulatoryStatusBuilderOptions
+    public class OverlayStatusBuilderOptions
     {
         
     }

--- a/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayTypeBuilder.cs
+++ b/source/WesternStatesWater.WaDE.Tests.Helpers/ModelBuilder/EntityFramework/OverlayTypeBuilder.cs
@@ -4,7 +4,7 @@ using WesternStatesWater.WaDE.Accessors.EntityFramework;
 
 namespace WesternStatesWater.WaDE.Tests.Helpers.ModelBuilder.EntityFramework
 {
-    public static class RegulatoryOverlayTypeBuilder
+    public static class OverlayTypeBuilder
     {
         private static int _globalIndex = 0;
         public static OverlayTypeCV Create()


### PR DESCRIPTION

# Table Changes
* Column `RegulatoryStatusCV` on `Core.Overlay_dim` renamed to `OverlayStatusCV`
* Table `CVs.RegulatoryStatus` renamed to `CVs.OverlayStatus`

# User-Defined Table Types
* Type `Core.OverlayTableType column `RegulatoryStatusCV` renamed to `OverlayStatusCV`

# Stored Procedures
* Altered `Core.LoadOverlays` to point to new namings

# Import File Changes
* `overlays.csv` renamed column `RegulatoryStatusCV` to `OverlayStatusCV`

# API V1 Changes
No contract changes were made.

# API V2 Changes
* Overlay Feature Item Properties
  * `regulatoryStatusCv` renamed to `overlayStatusCv`